### PR TITLE
fix: 对qqbot中group/channel ID进行大小写规范化，解决openclaw中bindings无法生效问题

### DIFF
--- a/extensions/qqbot/src/bot.ts
+++ b/extensions/qqbot/src/bot.ts
@@ -448,7 +448,7 @@ function resolveInbound(eventType: string, data: unknown): QQInboundMessage | nu
 
 function resolveChatTarget(event: QQInboundMessage): { to: string; peerId: string; peerKind: "group" | "dm" } {
   if (event.type === "group") {
-    const group = event.groupOpenid ?? "";
+    const group = (event.groupOpenid ?? "").toLowerCase();
     return {
       to: `group:${group}`,
       peerId: `group:${group}`,
@@ -456,7 +456,7 @@ function resolveChatTarget(event: QQInboundMessage): { to: string; peerId: strin
     };
   }
   if (event.type === "channel") {
-    const channel = event.channelId ?? "";
+    const channel = (event.channelId ?? "").toLowerCase();
     return {
       to: `channel:${channel}`,
       peerId: `channel:${channel}`,
@@ -472,10 +472,10 @@ function resolveChatTarget(event: QQInboundMessage): { to: string; peerId: strin
 
 function resolveEnvelopeFrom(event: QQInboundMessage): string {
   if (event.type === "group") {
-    return `group:${event.groupOpenid ?? "unknown"}`;
+    return `group:${(event.groupOpenid ?? "unknown").toLowerCase()}`;
   }
   if (event.type === "channel") {
-    return `channel:${event.channelId ?? "unknown"}`;
+    return `channel:${(event.channelId ?? "unknown").toLowerCase()}`;
   }
   return event.senderName?.trim() || event.senderId;
 }

--- a/extensions/qqbot/src/client.ts
+++ b/extensions/qqbot/src/client.ts
@@ -159,7 +159,8 @@ export async function sendGroupMessage(params: {
     messageId: params.messageId,
     markdown: params.markdown,
   });
-  return apiPost(params.accessToken, `/v2/groups/${params.groupOpenid}/messages`, body, {
+  const groupOpenidLower = params.groupOpenid.toLowerCase();
+  return apiPost(params.accessToken, `/v2/groups/${groupOpenidLower}/messages`, body, {
     timeout: 15000,
   });
 }
@@ -174,7 +175,8 @@ export async function sendChannelMessage(params: {
   if (params.messageId) {
     body.msg_id = params.messageId;
   }
-  return apiPost(params.accessToken, `/channels/${params.channelId}/messages`, body, {
+  const channelIdLower = params.channelId.toLowerCase();
+  return apiPost(params.accessToken, `/channels/${channelIdLower}/messages`, body, {
     timeout: 15000,
   });
 }


### PR DESCRIPTION
## 问题概述

QQ Bot 扩展中存在 **两个关键的大小写敏感性问题**，导致：
1. **Agent 路由失败** - Openclaw的agent配置里，bindings中groupid只能识别大写，小写无法路由到正确的 agent
2. **发送消息失败** - 如果上面使用大写，但由于发送消息时只识别小写，导致消息无法成功发送到 QQ 群
openclaw.json配置示例：
```
  "bindings": [
    {
      "agentId": "coder",
      "match": {
        "channel": "qqbot",
        "accountId": "*",
        "peer": {
          "kind": "group",
          "id": "group:10cd7ed5a9a8760dxxxxxxxxxxxxxxxx"
        }
      }
    }
  ],
```
上述两个功能无法同时work，必须对大小写进行规范。

以下详情内容为AI生成：

---

## 问题详情

### 问题 1: 入站消息处理中的大小写不一致（Agent 路由失败）

**位置**: `src/bot.ts` 中的 `resolveChatTarget()` 函数（第 449-471 行）

**问题描述**:
```typescript
function resolveChatTarget(event: QQInboundMessage): { to: string; peerId: string; peerKind: "group" | "dm" } {
  if (event.type === "group") {
    const group = event.groupOpenid ?? "";  // ❌ 直接使用，没有大小写规范化
    return {
      to: `group:${group}`,
      peerId: `group:${group}`,  // 例如: "group:10CD7ED5A9A8760DXXXXXXXXXXXXXXXX" (大写)，这里只有大写能生效
      peerKind: "group",
    };
  }
  // ...
}
```

**根本原因**:
- QQ Bot API 返回的 `groupOpenid` 是 **大写** 的（例如 `10CD7ED5A9A8760DXXXXXXXXXXXXXXXX`）
- 但这个函数没有对其进行大小写规范化
- 生成的 `peerId` 为 `group:10CD7ED5A9A8760DXXXXXXXXXXXXXXXX`（大写）

**造成的问题**:
- OpenClaw 核心的 agent 路由系统使用 `peerId` 与配置中的 binding 进行匹配
- 用户在配置文件中定义的 binding ID 通常是小写的
- 由于大小写不匹配，路由匹配失败 ❌
- 消息无法路由到指定的 agent（例如 `coder`），而是回落到默认 agent（`main`）

**业务影响**:
- 用户配置的 agent binding 完全失效
- 所有 QQ 群消息都路由到默认 agent，无法实现消息分流

---

### 问题 2: 出站消息处理中的大小写不一致（发送消息失败）

**位置**: `src/outbound.ts` 中的 `sendGroupMessage()` 函数（第 150-165 行）

**问题描述**:
```typescript
export async function sendGroupMessage(params: {
  accessToken: string;
  groupOpenid: string;
  content: string;
  messageId?: string;
  markdown?: boolean;
}): Promise<{ id: string; timestamp: number | string }> {
  const body = buildMessageBody({
    content: params.content,
    messageId: params.messageId,
    markdown: params.markdown
  });
  // ❌ 直接使用 params.groupOpenid，没有大小写规范化
  return apiPost(params.accessToken, `/v2/groups/${params.groupOpenid}/messages`, body, {
    timeout: 15000
  });
}
```

**根本原因**:
- 从 `parseTarget()` 获得的 group ID 可能是大写的（源自入站消息的 `groupOpenid`）
- 但 QQ Bot API 期望的是 **小写** 的 group ID（这是 QQ Bot 官方 API 的要求）
- 发送时使用大写 ID 调用 API 会导致请求失败


**HTTP 错误**:
```json
{
  "channel": "qqbot",
  "error": "HTTP 400: Bad Request"
}
```

**业务影响**:
- 即使 agent 路由正确，消息发送也会失败（HTTP 400）
- 用户收不到 agent 的回复

---

## 解决方案

### 修复 1: 规范化入站消息中的 Group ID

**文件**: `src/bot.ts`

**修改 `resolveChatTarget()` 函数**:
```typescript
function resolveChatTarget(event: QQInboundMessage): { to: string; peerId: string; peerKind: "group" | "dm" } {
  if (event.type === "group") {
    // ✅ 添加 .toLowerCase() 规范化
    const group = (event.groupOpenid ?? "").toLowerCase();
    return {
      to: `group:${group}`,
      peerId: `group:${group}`,  // 现在为: "group:10cd7ed5a9a8760da4749bd77a1ddfbd" (小写)
      peerKind: "group",
    };
  }
  if (event.type === "channel") {
    // ✅ 添加 .toLowerCase() 规范化
    const channel = (event.channelId ?? "").toLowerCase();
    return {
      to: `channel:${channel}`,
      peerId: `channel:${channel}`,
      peerKind: "group",
    };
  }
  return {
    to: `user:${event.senderId}`,
    peerId: event.senderId,
    peerKind: "dm",
  };
}
```

**效果**:
- 生成的 `peerId` 始终是小写的
- 与配置中的 binding ID 匹配 ✅
- agent 路由成功

---

### 修复 2: 规范化出站消息中的 Group ID

**文件**: `src/outbound.ts`

**修改 `sendGroupMessage()` 函数**:
```typescript
export async function sendGroupMessage(params: {
  accessToken: string;
  groupOpenid: string;
  content: string;
  messageId?: string;
  markdown?: boolean;
}): Promise<{ id: string; timestamp: number | string }> {
  const body = buildMessageBody({
    content: params.content,
    messageId: params.messageId,
    markdown: params.markdown
  });
  // ✅ 添加 .toLowerCase() 规范化，确保 API 接收小写 ID
  const groupOpenidLower = params.groupOpenid.toLowerCase();
  return apiPost(params.accessToken, `/v2/groups/${groupOpenidLower}/messages`, body, {
    timeout: 15000
  });
}
```

**效果**:
- API 请求始终使用小写 group ID
- 消息发送成功 ✅
- 用户收到 agent 回复

---

### 修复 3: 同步规范化 Channel ID（预防性修复）

**文件**: `src/outbound.ts`

**修改 `sendChannelMessage()` 函数**:
```typescript
export async function sendChannelMessage(params: {
  accessToken: string;
  channelId: string;
  content: string;
  messageId?: string;
}): Promise<{ id: string; timestamp: number | string }> {
  const body: Record<string, unknown> = { content: params.content };
  if (params.messageId) {
    body.msg_id = params.messageId;
  }
  // ✅ 添加 .toLowerCase() 规范化
  const channelIdLower = params.channelId.toLowerCase();
  return apiPost(params.accessToken, `/channels/${channelIdLower}/messages`, body, {
    timeout: 15000
  });
}
```

---

## 测试验证

修复后验证检查清单：

- [ ] 在配置文件中定义小写 group ID 的 binding，例如:
  ```json
  {
    "agentId": "coder",
    "match": {
      "channel": "qqbot",
      "peer": {
        "kind": "group",
        "id": "group:10cd7ed5a9a8760dxxxxxxxxxxxxxxxx"
      }
    }
  }
  ```

- [ ] 发送 QQ 群消息，验证:
  - ✅ 消息路由到正确的 agent（`coder` 而非 `main`）
  - ✅ Agent 处理完成
  - ✅ 消息成功发送回 QQ 群
  - ✅ 用户收到回复

- [ ] 日志验证:
  - ✅ `peerId` 始终显示为小写：`group:10cd7ed5a9a8760dxxxxxxxxxxxxxxxx`
  - ✅ 没有 HTTP 400 错误
  - ✅ API 调用成功

---


## 总结表

| 维度 | 问题 | 影响 | 修复 |
|------|------|------|------|
| **入站处理** | `resolveChatTarget()` 未规范化大小写 | Agent 路由失败 | 添加 `.toLowerCase()` |
| **出站处理** | `sendGroupMessage()` 未规范化大小写 | 消息发送失败 (HTTP 400) | 添加 `.toLowerCase()` |
| **会话标签** | 依赖小写 ID 进行会话查找 | 会话查询失败 | 入站处理修复后自动解决 |
| **Channel 处理** | `sendChannelMessage()` 也可能有同样问题 | 频道消息发送可能失败 | 预防性添加 `.toLowerCase()` |
