### PR TITLE
feat(wecom-app): 增加wecom-app语音调用腾讯云asr转写

### DIFF
--- a/extensions/wecom-app/openclaw.plugin.json
+++ b/extensions/wecom-app/openclaw.plugin.json
@@ -18,6 +18,18 @@
       "token": { "type": "string" },
       "encodingAESKey": { "type": "string" },
       "receiveId": { "type": "string" },
+      "asr": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "appId": { "type": "string" },
+          "secretId": { "type": "string" },
+          "secretKey": { "type": "string" },
+          "engineType": { "type": "string" },
+          "timeoutMs": { "type": "number" }
+        }
+      },
       "welcomeText": { "type": "string" },
       "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist", "disabled"] },
       "allowFrom": { "type": "array", "items": { "type": "string" } },
@@ -41,6 +53,18 @@
             "token": { "type": "string" },
             "encodingAESKey": { "type": "string" },
             "receiveId": { "type": "string" },
+            "asr": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "appId": { "type": "string" },
+                "secretId": { "type": "string" },
+                "secretKey": { "type": "string" },
+                "engineType": { "type": "string" },
+                "timeoutMs": { "type": "number" }
+              }
+            },
             "welcomeText": { "type": "string" },
             "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist", "disabled"] },
             "allowFrom": { "type": "array", "items": { "type": "string" } },

--- a/extensions/wecom-app/src/config.ts
+++ b/extensions/wecom-app/src/config.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import type {
   ResolvedWecomAppAccount,
   WecomAppAccountConfig,
+  WecomAppASRCredentials,
   WecomAppConfig,
   WecomAppDmPolicy,
 } from "./types.js";
@@ -48,6 +49,16 @@ const WecomAppAccountSchema = z.object({
     .object({
       enabled: z.boolean().optional(),
       prefer: z.enum(["amr"]).optional(),
+    })
+    .optional(),
+  asr: z
+    .object({
+      enabled: z.boolean().optional(),
+      appId: z.string().optional(),
+      secretId: z.string().optional(),
+      secretKey: z.string().optional(),
+      engineType: z.string().optional(),
+      timeoutMs: z.number().int().positive().optional(),
     })
     .optional(),
 
@@ -97,6 +108,18 @@ export const WecomAppConfigJsonSchema = {
           prefer: { type: "string", enum: ["amr"] },
         },
       },
+      asr: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          enabled: { type: "boolean" },
+          appId: { type: "string" },
+          secretId: { type: "string" },
+          secretKey: { type: "string" },
+          engineType: { type: "string" },
+          timeoutMs: { type: "number" },
+        },
+      },
       welcomeText: { type: "string" },
       dmPolicy: { type: "string", enum: ["open", "pairing", "allowlist", "disabled"] },
       allowFrom: { type: "array", items: { type: "string" } },
@@ -126,6 +149,18 @@ export const WecomAppConfigJsonSchema = {
                 dir: { type: "string" },
                 maxBytes: { type: "number" },
                 keepDays: { type: "number" },
+              },
+            },
+            asr: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                enabled: { type: "boolean" },
+                appId: { type: "string" },
+                secretId: { type: "string" },
+                secretKey: { type: "string" },
+                engineType: { type: "string" },
+                timeoutMs: { type: "number" },
               },
             },
             welcomeText: { type: "string" },
@@ -304,4 +339,17 @@ export function resolveInboundMediaKeepDays(config: WecomAppAccountConfig): numb
 export function resolveMaxFileSizeMB(config: WecomAppAccountConfig): number {
   const v = config.maxFileSizeMB;
   return typeof v === "number" && Number.isFinite(v) && v > 0 ? v : 100;
+}
+
+export function resolveWecomAppASRCredentials(config: WecomAppAccountConfig): WecomAppASRCredentials | undefined {
+  const asr = config.asr;
+  if (!asr?.enabled) return undefined;
+  if (!asr.appId || !asr.secretId || !asr.secretKey) return undefined;
+  return {
+    appId: asr.appId,
+    secretId: asr.secretId,
+    secretKey: asr.secretKey,
+    engineType: asr.engineType,
+    timeoutMs: asr.timeoutMs,
+  };
 }

--- a/extensions/wecom-app/src/types.ts
+++ b/extensions/wecom-app/src/types.ts
@@ -57,6 +57,18 @@ export type WecomAppAccountConfig = {
     prefer?: "amr";
   };
 
+  /**
+   * 入站语音 ASR 配置（腾讯云录音文件识别极速版）
+   */
+  asr?: {
+    enabled?: boolean;
+    appId?: string;
+    secretId?: string;
+    secretKey?: string;
+    engineType?: string;
+    timeoutMs?: number;
+  };
+
   /** 欢迎文本 */
   welcomeText?: string;
 
@@ -72,6 +84,14 @@ export type WecomAppAccountConfig = {
 export type WecomAppConfig = WecomAppAccountConfig & {
   accounts?: Record<string, WecomAppAccountConfig>;
   defaultAccount?: string;
+};
+
+export type WecomAppASRCredentials = {
+  appId: string;
+  secretId: string;
+  secretKey: string;
+  engineType?: string;
+  timeoutMs?: number;
 };
 
 /**
@@ -157,6 +177,25 @@ export type WecomAppInboundImage = WecomAppInboundBase & {
   MediaId?: string;
 };
 
+export type WecomAppInboundLocation = WecomAppInboundBase & {
+  msgtype: "location";
+  MsgType?: "location";
+  /** 纬度 */
+  Location_X?: string;
+  /** 经度 */
+  Location_Y?: string;
+  /** 地图缩放级别 */
+  Scale?: string;
+  /** 地理位置文本 */
+  Label?: string;
+  location?: {
+    lat?: string;
+    lon?: string;
+    scale?: string;
+    label?: string;
+  };
+};
+
 export type WecomAppInboundEvent = WecomAppInboundBase & {
   msgtype: "event";
   MsgType?: "event";
@@ -178,6 +217,7 @@ export type WecomAppInboundMessage =
   | WecomAppInboundText
   | WecomAppInboundVoice
   | WecomAppInboundImage
+  | WecomAppInboundLocation
   | WecomAppInboundStreamRefresh
   | WecomAppInboundEvent
   | (WecomAppInboundBase & Record<string, unknown>);


### PR DESCRIPTION
## 2026-02-13

### wecom-app

- 增强语音转写（ASR）能力
  - 入站 `voice` 消息优先走云端 ASR 转写。
  - 转写成功后在消息体追加识别文本（`[recognition] ...`）。
  - ASR 失败时自动回退到企业微信原生 `Recognition` 字段（若存在）。

- 增强语音发送兼容（wav/mp3 → amr）
  - 新增 `voiceTranscode.enabled` 配置。
  - 发送 `wav/mp3` 时，若检测到 `ffmpeg`，自动转码为 `amr` 再按语音发送。
  - 若无 `ffmpeg` 或转码失败，自动降级为文件发送，保证消息可达。

