### PR TITLE
feat(wecom-app): wecom-app 增加腾讯云 ASR 语音转写支持

### DIFF
--- a/extensions/wecom-app/openclaw.plugin.json
+++ b/extensions/wecom-app/openclaw.plugin.json
@@ -18,6 +18,18 @@
       "token": { "type": "string" },
       "encodingAESKey": { "type": "string" },
       "receiveId": { "type": "string" },
+      "asr": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "appId": { "type": "string" },
+          "secretId": { "type": "string" },
+          "secretKey": { "type": "string" },
+          "engineType": { "type": "string" },
+          "timeoutMs": { "type": "number" }
+        }
+      },
       "welcomeText": { "type": "string" },
       "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist", "disabled"] },
       "allowFrom": { "type": "array", "items": { "type": "string" } },
@@ -41,6 +53,18 @@
             "token": { "type": "string" },
             "encodingAESKey": { "type": "string" },
             "receiveId": { "type": "string" },
+            "asr": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "appId": { "type": "string" },
+                "secretId": { "type": "string" },
+                "secretKey": { "type": "string" },
+                "engineType": { "type": "string" },
+                "timeoutMs": { "type": "number" }
+              }
+            },
             "welcomeText": { "type": "string" },
             "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist", "disabled"] },
             "allowFrom": { "type": "array", "items": { "type": "string" } },

--- a/extensions/wecom-app/src/bot.ts
+++ b/extensions/wecom-app/src/bot.ts
@@ -8,13 +8,16 @@
 import {
   checkDmPolicy,
   createLogger,
+  transcribeTencentFlash,
   type Logger,
 } from "@openclaw-china/shared";
+import { readFile } from "node:fs/promises";
 
 import type { PluginRuntime } from "./runtime.js";
 import type { ResolvedWecomAppAccount, WecomAppInboundMessage, WecomAppDmPolicy } from "./types.js";
 import {
   resolveAllowFrom,
+  resolveWecomAppASRCredentials,
   resolveDmPolicy,
   resolveInboundMediaEnabled,
   resolveInboundMediaMaxBytes,
@@ -33,6 +36,15 @@ export type WecomAppDispatchHooks = {
   onChunk: (text: string) => void;
   onError?: (err: unknown) => void;
 };
+
+function resolveVoiceFormat(msg: WecomAppInboundMessage, savedPath: string): string {
+  const declared = String((msg as { Format?: string }).Format ?? "").trim().toLowerCase();
+  if (declared === "amr" || declared === "speex") return declared;
+  const lowerPath = savedPath.toLowerCase();
+  if (lowerPath.endsWith(".speex")) return "speex";
+  if (lowerPath.endsWith(".amr")) return "amr";
+  return "silk";
+}
 
 /**
  * 提取消息内容
@@ -186,12 +198,49 @@ export async function enrichInboundContentWithMedia(params: {
     try {
       const mediaId = String((msg as { MediaId?: string }).MediaId ?? "").trim();
       const recognition = String((msg as { Recognition?: string }).Recognition ?? "").trim();
+      const asrCredentials = resolveWecomAppASRCredentials(accountConfig);
 
       if (mediaId) {
         const saved = await downloadWecomMediaToFile(account, mediaId, { maxBytes, prefix: "voice" });
         if (saved.ok && saved.path) {
           const finalPath = await finalizeInboundMedia(account, saved.path);
           mediaPaths.push(finalPath);
+
+          if (asrCredentials) {
+            try {
+              const audio = await readFile(finalPath);
+              const asrConfig: {
+                appId: string;
+                secretId: string;
+                secretKey: string;
+                engineType?: string;
+                voiceFormat: string;
+                timeoutMs?: number;
+              } = {
+                appId: asrCredentials.appId,
+                secretId: asrCredentials.secretId,
+                secretKey: asrCredentials.secretKey,
+                voiceFormat: resolveVoiceFormat(msg, finalPath),
+              };
+              if (asrCredentials.engineType) {
+                asrConfig.engineType = asrCredentials.engineType;
+              }
+              if (typeof asrCredentials.timeoutMs === "number") {
+                asrConfig.timeoutMs = asrCredentials.timeoutMs;
+              }
+              const transcript = await transcribeTencentFlash({
+                audio,
+                config: asrConfig,
+              });
+              const safeTranscript = transcript.trim();
+              if (safeTranscript) {
+                return makeResult(`[voice] saved:${finalPath}\n[recognition] ${safeTranscript}`);
+              }
+            } catch (err) {
+              // ASR 失败时保持兼容回退：优先使用企业微信自带 Recognition，再回退文件路径。
+            }
+          }
+
           // 如果有识别文本，包含它以便 Agent 看到转录内容
           if (recognition) {
             return makeResult(`[voice] saved:${finalPath}\n[recognition] ${recognition}`);

--- a/extensions/wecom-app/src/config.ts
+++ b/extensions/wecom-app/src/config.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import type {
   ResolvedWecomAppAccount,
   WecomAppAccountConfig,
+  WecomAppASRCredentials,
   WecomAppConfig,
   WecomAppDmPolicy,
 } from "./types.js";
@@ -48,6 +49,16 @@ const WecomAppAccountSchema = z.object({
     .object({
       enabled: z.boolean().optional(),
       prefer: z.enum(["amr"]).optional(),
+    })
+    .optional(),
+  asr: z
+    .object({
+      enabled: z.boolean().optional(),
+      appId: z.string().optional(),
+      secretId: z.string().optional(),
+      secretKey: z.string().optional(),
+      engineType: z.string().optional(),
+      timeoutMs: z.number().int().positive().optional(),
     })
     .optional(),
 
@@ -97,6 +108,18 @@ export const WecomAppConfigJsonSchema = {
           prefer: { type: "string", enum: ["amr"] },
         },
       },
+      asr: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          enabled: { type: "boolean" },
+          appId: { type: "string" },
+          secretId: { type: "string" },
+          secretKey: { type: "string" },
+          engineType: { type: "string" },
+          timeoutMs: { type: "number" },
+        },
+      },
       welcomeText: { type: "string" },
       dmPolicy: { type: "string", enum: ["open", "pairing", "allowlist", "disabled"] },
       allowFrom: { type: "array", items: { type: "string" } },
@@ -126,6 +149,18 @@ export const WecomAppConfigJsonSchema = {
                 dir: { type: "string" },
                 maxBytes: { type: "number" },
                 keepDays: { type: "number" },
+              },
+            },
+            asr: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                enabled: { type: "boolean" },
+                appId: { type: "string" },
+                secretId: { type: "string" },
+                secretKey: { type: "string" },
+                engineType: { type: "string" },
+                timeoutMs: { type: "number" },
               },
             },
             welcomeText: { type: "string" },
@@ -304,4 +339,17 @@ export function resolveInboundMediaKeepDays(config: WecomAppAccountConfig): numb
 export function resolveMaxFileSizeMB(config: WecomAppAccountConfig): number {
   const v = config.maxFileSizeMB;
   return typeof v === "number" && Number.isFinite(v) && v > 0 ? v : 100;
+}
+
+export function resolveWecomAppASRCredentials(config: WecomAppAccountConfig): WecomAppASRCredentials | undefined {
+  const asr = config.asr;
+  if (!asr?.enabled) return undefined;
+  if (!asr.appId || !asr.secretId || !asr.secretKey) return undefined;
+  return {
+    appId: asr.appId,
+    secretId: asr.secretId,
+    secretKey: asr.secretKey,
+    engineType: asr.engineType,
+    timeoutMs: asr.timeoutMs,
+  };
 }

--- a/extensions/wecom-app/src/types.ts
+++ b/extensions/wecom-app/src/types.ts
@@ -57,6 +57,18 @@ export type WecomAppAccountConfig = {
     prefer?: "amr";
   };
 
+  /**
+   * 入站语音 ASR 配置（腾讯云录音文件识别极速版）
+   */
+  asr?: {
+    enabled?: boolean;
+    appId?: string;
+    secretId?: string;
+    secretKey?: string;
+    engineType?: string;
+    timeoutMs?: number;
+  };
+
   /** 欢迎文本 */
   welcomeText?: string;
 
@@ -72,6 +84,14 @@ export type WecomAppAccountConfig = {
 export type WecomAppConfig = WecomAppAccountConfig & {
   accounts?: Record<string, WecomAppAccountConfig>;
   defaultAccount?: string;
+};
+
+export type WecomAppASRCredentials = {
+  appId: string;
+  secretId: string;
+  secretKey: string;
+  engineType?: string;
+  timeoutMs?: number;
 };
 
 /**


### PR DESCRIPTION
wecom-app
增强语音转写（ASR）能力

入站 voice 消息优先走云端 ASR 转写。
转写成功后在消息体追加识别文本（[recognition] ...）。
ASR 失败时自动回退到企业微信原生 Recognition 字段（若存在）。
增强语音发送兼容（wav/mp3 → amr）

新增 voiceTranscode.enabled 配置。
发送 wav/mp3 时，若检测到 ffmpeg，自动转码为 amr 再按语音发送。
若无 ffmpeg 或转码失败，自动降级为文件发送，保证消息可达。