### PR TITLE
feat(wecom-app): wecom-app中支持以视频播放器形式发送mp4视频

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,18 +130,12 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.7
-      fast-check:
-        specifier: ^3.22.0
-        version: 3.23.2
       tsup:
         specifier: ^8.2.0
         version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
-      vitest:
-        specifier: ^2.1.0
-        version: 2.1.9(@types/node@22.19.7)
       zod:
         specifier: ^3.23.0
         version: 3.25.76


### PR DESCRIPTION
## PR 描述
为企业微信自建应用插件添加视频消息发送支持，使 MP4 格式的视频文件能够以视频播放器的形式展示，而不是作为普通文件发送。（Agent发自拍视频的时候会更自然）

## 更改的文件
1. **extensions/wecom-app/src/channel.ts**
   - 修改了 `MediaType` 类型定义，添加了 `"video"` 类型
   - 更新了 `detectMediaType` 函数，添加了对视频 MIME 类型和扩展名的检测（仅支持 MP4）
   - 在 `sendMedia` 方法中添加了对视频类型的处理逻辑

2. **extensions/wecom-app/src/api.ts**
   - 添加了 `sendWecomAppVideoMessage` 函数，用于发送视频消息
   - 添加了 `downloadAndSendVideo` 函数，实现了视频的完整发送流程

3. **pnpm-lock.yaml**
   - 更新了依赖锁文件（自动生成）

## 实现原理
1. **媒体类型检测**：
   - MIME 类型检测：仅识别 `video/mp4` 和 `video/mpeg` 为视频类型
   - 文件扩展名检测：仅识别 `.mp4` 扩展名为视频类型

2. **视频发送流程**：
   - 下载视频：使用现有的 `downloadFile` 函数
   - 提取文件信息：保留原始文件名，确保用户体验
   - 上传素材：使用现有的 `uploadMedia` 函数，指定类型为 `"video"`
   - 发送视频消息：使用新添加的 `sendWecomAppVideoMessage` 函数

3. **代码复用**：
   - 复用了 `downloadFile` 函数：用于下载视频文件
   - 复用了 `uploadMedia` 函数：用于上传视频素材，获取 media_id
   - 复用了现有的错误处理和日志记录机制：确保视频发送的可靠性

## 使用示例
### 发送本地 MP4 视频文件
```typescript
import { sendWecom } from "@openclaw-china/wecom-app";

// 发送本地视频文件
await sendWecom(account, "user:xxxx", {
  mediaPath: "/path/to/video.mp4"
});
```

### 发送网络 MP4 视频文件
```typescript
import { sendWecom } from "@openclaw-china/wecom-app";

// 发送网络视频文件
await sendWecom(account, "user:xxxx", {
  mediaPath: "https://example.com/video.mp4"
});
```
