### PR TITLE
fix(qqbot): keep TTS media delivery when replyFinalOnly=true

### DIFF
--- a/doc/guides/qqbot/configuration.md
+++ b/doc/guides/qqbot/configuration.md
@@ -134,7 +134,7 @@ openclaw config set gateway.http.endpoints.chatCompletions.enabled true
 | allowFrom | string[] | [] | 私聊白名单 |
 | groupAllowFrom | string[] | [] | 群聊白名单 |
 | textChunkLimit | number | 1500 | 文本分块长度 |
-| replyFinalOnly | boolean | false | 是否仅发送最终回复 |
+| replyFinalOnly | boolean | false | 是否仅发送最终回复文本（不会阻断媒体工具结果，如 TTS 语音） |
 
 ---
 

--- a/extensions/qqbot/package.json
+++ b/extensions/qqbot/package.json
@@ -88,6 +88,8 @@
   },
   "dependencies": {
     "@openclaw-china/shared": "workspace:*",
+    "ffmpeg-static": "^5.3.0",
+    "silk-wasm": "^3.7.1",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/extensions/qqbot/src/bot.reply-final-only.test.ts
+++ b/extensions/qqbot/src/bot.reply-final-only.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "@openclaw-china/shared";
+import {
+  evaluateReplyFinalOnlyDelivery,
+  sanitizeQQBotOutboundText,
+  sendQQBotMediaWithFallback,
+} from "./bot.js";
+
+describe("evaluateReplyFinalOnlyDelivery", () => {
+  it("allows non-final tool payload when media exists, and suppresses text", () => {
+    const decision = evaluateReplyFinalOnlyDelivery({
+      replyFinalOnly: true,
+      kind: "tool",
+      hasMedia: true,
+      sanitizedText: "语音说明",
+    });
+    expect(decision).toEqual({ skipDelivery: false, suppressText: true });
+  });
+
+  it("skips non-final text-only payload when replyFinalOnly is enabled", () => {
+    const decision = evaluateReplyFinalOnlyDelivery({
+      replyFinalOnly: true,
+      kind: "tool",
+      hasMedia: false,
+      sanitizedText: "仅文本",
+    });
+    expect(decision).toEqual({ skipDelivery: true, suppressText: false });
+  });
+
+  it("keeps final event but strips NO_REPLY to empty outbound text", () => {
+    const sanitized = sanitizeQQBotOutboundText("NO_REPLY");
+    const decision = evaluateReplyFinalOnlyDelivery({
+      replyFinalOnly: true,
+      kind: "final",
+      hasMedia: false,
+      sanitizedText: sanitized,
+    });
+    const textToSend = decision.suppressText ? "" : sanitized;
+    expect(decision.skipDelivery).toBe(false);
+    expect(textToSend).toBe("");
+  });
+
+  it("does not suppress block text when replyFinalOnly is disabled", () => {
+    const sanitized = sanitizeQQBotOutboundText("普通文本");
+    const decision = evaluateReplyFinalOnlyDelivery({
+      replyFinalOnly: false,
+      kind: "block",
+      hasMedia: false,
+      sanitizedText: sanitized,
+    });
+    const textToSend = decision.suppressText ? "" : sanitized;
+    expect(decision).toEqual({ skipDelivery: false, suppressText: false });
+    expect(textToSend).toBe("普通文本");
+  });
+});
+
+describe("sendQQBotMediaWithFallback", () => {
+  it("falls back to text when sendMedia fails", async () => {
+    const sendMedia = vi.fn().mockResolvedValue({ channel: "qqbot", error: "upload failed" });
+    const sendText = vi.fn().mockResolvedValue({ channel: "qqbot", messageId: "m1", timestamp: 1 });
+    const logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger;
+
+    await sendQQBotMediaWithFallback({
+      qqCfg: {},
+      to: "user:123",
+      mediaQueue: ["https://example.com/a.mp3"],
+      replyToId: "reply-1",
+      logger,
+      outbound: { sendMedia, sendText },
+    });
+
+    expect(sendMedia).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText.mock.calls[0]?.[0]?.text).toContain("https://example.com/a.mp3");
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("sendMedia failed"));
+  });
+});

--- a/extensions/qqbot/src/bot.text-sanitize.test.ts
+++ b/extensions/qqbot/src/bot.text-sanitize.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  sanitizeQQBotOutboundText,
+  shouldSuppressQQBotTextWhenMediaPresent,
+} from "./bot.js";
+
+describe("sanitizeQQBotOutboundText", () => {
+  it("keeps final content and strips think blocks + emotion tags", () => {
+    const input = "<think>internal</think><final>欸，末夕 [chuckles]</final>";
+    expect(sanitizeQQBotOutboundText(input)).toBe("欸，末夕");
+  });
+
+  it("strips directive tags from tts-style content", () => {
+    const input = "[[reply_to_current]] [[tts:text]][playfully] 你好呀 [[/tts:text]]";
+    expect(sanitizeQQBotOutboundText(input)).toBe("你好呀");
+  });
+
+  it("suppresses NO_REPLY sentinel", () => {
+    expect(sanitizeQQBotOutboundText(" NO_REPLY ")).toBe("");
+  });
+});
+
+describe("shouldSuppressQQBotTextWhenMediaPresent", () => {
+  it("suppresses tts echo text when media is present", () => {
+    const raw = "[[tts:text]][chuckles] 你好[[/tts:text]]";
+    const cleaned = sanitizeQQBotOutboundText(raw);
+    expect(shouldSuppressQQBotTextWhenMediaPresent(raw, cleaned)).toBe(true);
+  });
+
+  it("keeps normal plain text when media is present", () => {
+    const raw = "这是补充说明，请同时查看语音。";
+    const cleaned = sanitizeQQBotOutboundText(raw);
+    expect(shouldSuppressQQBotTextWhenMediaPresent(raw, cleaned)).toBe(false);
+  });
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,15 @@ importers:
       '@openclaw-china/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      ffmpeg-static:
+        specifier: ^5.3.0
+        version: 5.3.0
       moltbot:
         specifier: '>=0.1.0'
         version: 0.1.0
+      silk-wasm:
+        specifier: ^3.7.1
+        version: 3.7.1
       ws:
         specifier: ^8.18.0
         version: 8.19.0
@@ -225,6 +231,10 @@ packages:
 
   '@clack/prompts@1.0.1':
     resolution: {integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==}
+
+  '@derhuerst/http-basic@8.2.4':
+    resolution: {integrity: sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==}
+    engines: {node: '>=6.0.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -786,6 +796,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@10.17.60':
+    resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
+
   '@types/node@22.19.7':
     resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
 
@@ -826,6 +839,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -841,6 +858,9 @@ packages:
 
   axios@1.13.4:
     resolution: {integrity: sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -859,6 +879,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -879,6 +902,10 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -910,6 +937,10 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -960,6 +991,10 @@ packages:
       picomatch:
         optional: true
 
+  ffmpeg-static@5.3.0:
+    resolution: {integrity: sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==}
+    engines: {node: '>=16'}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
@@ -1007,6 +1042,16 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  http-response-object@3.0.2:
+    resolution: {integrity: sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1084,6 +1129,9 @@ packages:
     engines: {node: '>=8.*'}
     hasBin: true
 
+  parse-cache-control@1.0.1:
+    resolution: {integrity: sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -1130,6 +1178,10 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
@@ -1144,6 +1196,10 @@ packages:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -1156,6 +1212,9 @@ packages:
     resolution: {integrity: sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -1176,6 +1235,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  silk-wasm@3.7.1:
+    resolution: {integrity: sha512-mXPwLRtZxrYV3TZx41jMAeKc80wvmyrcXIcs8HctFxK15Ahz2OJQENYhNgEPeCEOdI6Mbx1NxQsqxzwc3DKerw==}
+    engines: {node: '>=16.11.0'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -1192,6 +1255,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -1253,6 +1319,9 @@ packages:
       typescript:
         optional: true
 
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1263,6 +1332,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1357,6 +1429,13 @@ snapshots:
       '@clack/core': 1.0.1
       picocolors: 1.1.1
       sisteransi: 1.0.5
+
+  '@derhuerst/http-basic@8.2.4':
+    dependencies:
+      caseless: 0.12.0
+      concat-stream: 2.0.0
+      http-response-object: 3.0.2
+      parse-cache-control: 1.0.1
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1700,6 +1779,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@10.17.60': {}
+
   '@types/node@22.19.7':
     dependencies:
       undici-types: 6.21.0
@@ -1750,6 +1831,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   any-promise@1.3.0: {}
 
   assertion-error@2.0.1: {}
@@ -1771,6 +1858,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  buffer-from@1.1.2: {}
+
   bundle-require@5.1.0(esbuild@0.27.2):
     dependencies:
       esbuild: 0.27.2
@@ -1787,6 +1876,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  caseless@0.12.0: {}
 
   chai@5.3.3:
     dependencies:
@@ -1807,6 +1898,13 @@ snapshots:
       delayed-stream: 1.0.0
 
   commander@4.1.1: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   confbox@0.1.8: {}
 
@@ -1835,6 +1933,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  env-paths@2.2.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -1922,6 +2022,15 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  ffmpeg-static@5.3.0:
+    dependencies:
+      '@derhuerst/http-basic': 8.2.4
+      env-paths: 2.2.1
+      https-proxy-agent: 5.0.1
+      progress: 2.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
@@ -1974,6 +2083,19 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  http-response-object@3.0.2:
+    dependencies:
+      '@types/node': 10.17.60
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  inherits@2.0.4: {}
 
   joycon@3.1.1: {}
 
@@ -2039,6 +2161,8 @@ snapshots:
       '@oxlint/win32-arm64': 0.16.12
       '@oxlint/win32-x64': 0.16.12
 
+  parse-cache-control@1.0.1: {}
+
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
@@ -2069,6 +2193,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  progress@2.0.3: {}
+
   protobufjs@7.5.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -2091,6 +2217,12 @@ snapshots:
   qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -2127,6 +2259,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.0
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -2157,6 +2291,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  silk-wasm@3.7.1: {}
+
   sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
@@ -2166,6 +2302,10 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   sucrase@3.35.1:
     dependencies:
@@ -2232,11 +2372,15 @@ snapshots:
       - tsx
       - yaml
 
+  typedarray@0.0.6: {}
+
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
+
+  util-deprecate@1.0.2: {}
 
   vite-node@2.1.9(@types/node@22.19.7):
     dependencies:


### PR DESCRIPTION
## 背景
QQ 私聊场景下，`replyFinalOnly=true` 时会在 `deliver` 入口提前丢弃 `kind !== final` 的事件，导致工具阶段 `tts` 返回的 `MEDIA:/...mp3` 被直接拦截。典型现象是：日志显示 `tts` 成功，但用户侧没有任何回复（最终 assistant 仅 `NO_REPLY`）。

## 变更
- 调整 `extensions/qqbot/src/bot.ts` 的下发顺序：
  - 先解析媒体与文本，再应用 `replyFinalOnly` 策略。
  - 新增 `evaluateReplyFinalOnlyDelivery(...)`：
    - 非 final + 无媒体 => `skipDelivery=true`
    - 非 final + 有媒体 => `skipDelivery=false` 且 `suppressText=true`
- 保留并增强文本清洗（去除 `<think>/<final>`、`[[tts:text]]`、`[chuckles]`、`NO_REPLY` 等噪声）
- 抽出 `sendQQBotMediaWithFallback(...)`，保证 `sendMedia` 失败时 fallback 文本仍会发送，避免完全静默。

## 测试
新增测试：`extensions/qqbot/src/bot.reply-final-only.test.ts`
- `replyFinalOnly=true + kind=tool + hasMedia=true`：媒体放行且文本抑制
- `replyFinalOnly=true + kind=tool + hasMedia=false`：正确跳过
- `final + NO_REPLY`：无文本下发
- `replyFinalOnly=false + kind=block`：回归通过
- `sendMedia` 失败 fallback 路径

并保留已有 `bot.text-sanitize.test.ts`。

本地验证：
- `pnpm -F @openclaw-china/qqbot test` (17 passed)
- `pnpm -F @openclaw-china/qqbot build` (success)

## 额外修复（同次提交）
- `extensions/qqbot/src/send.ts`：新增语音本地转码为 SILK 的发送路径（优先转换，失败回退原始上传），并添加依赖 `ffmpeg-static` + `silk-wasm`，修复 QQ 语音对 mp3 兼容性问题。
- 文档更新：`doc/guides/qqbot/configuration.md`，明确 `replyFinalOnly` 不阻断媒体工具结果（如 TTS 语音）。
