### PR TITLE
fix(wecom): adapt webhook registration to OpenClaw 2026.3.2 registerHttpRoute API

### DIFF
--- a/extensions/wecom-app/index.ts
+++ b/extensions/wecom-app/index.ts
@@ -28,9 +28,27 @@ import {
 /**
  * Moltbot 插件 API 接口
  */
+type HttpRouteMatch = "exact" | "prefix";
+type HttpRouteAuth = "gateway" | "plugin";
+
+type HttpRouteParams = {
+  path: string;
+  auth: HttpRouteAuth;
+  match?: HttpRouteMatch;
+  handler: (req: IncomingMessage, res: ServerResponse) => Promise<boolean> | boolean;
+};
+
 export interface MoltbotPluginApi {
   registerChannel: (opts: { plugin: unknown }) => void;
   registerHttpHandler?: (handler: (req: IncomingMessage, res: ServerResponse) => Promise<boolean> | boolean) => void;
+  registerHttpRoute?: (params: HttpRouteParams) => void;
+  config?: {
+    channels?: {
+      "wecom-app"?: {
+        webhookPath?: string;
+      };
+    };
+  };
   runtime?: unknown;
   [key: string]: unknown;
 }
@@ -92,7 +110,16 @@ const plugin = {
 
     api.registerChannel({ plugin: wecomAppPlugin });
 
-    if (api.registerHttpHandler) {
+    if (api.registerHttpRoute) {
+      const webhookPath = (api.config?.channels?.["wecom-app"]?.webhookPath ?? "/wecom-app").trim() || "/wecom-app";
+      api.registerHttpRoute({
+        path: webhookPath,
+        auth: "plugin",
+        match: "prefix",
+        handler: handleWecomAppWebhookRequest,
+      });
+    } else if (api.registerHttpHandler) {
+      // Backward compatibility for older OpenClaw core
       api.registerHttpHandler(handleWecomAppWebhookRequest);
     }
   },

--- a/extensions/wecom/index.ts
+++ b/extensions/wecom/index.ts
@@ -18,9 +18,27 @@ import { registerChinaSetupCli, showChinaInstallHint } from "@openclaw-china/sha
 /**
  * Moltbot 插件 API 接口
  */
+type HttpRouteMatch = "exact" | "prefix";
+type HttpRouteAuth = "gateway" | "plugin";
+
+type HttpRouteParams = {
+  path: string;
+  auth: HttpRouteAuth;
+  match?: HttpRouteMatch;
+  handler: (req: IncomingMessage, res: ServerResponse) => Promise<boolean> | boolean;
+};
+
 export interface MoltbotPluginApi {
   registerChannel: (opts: { plugin: unknown }) => void;
   registerHttpHandler?: (handler: (req: IncomingMessage, res: ServerResponse) => Promise<boolean> | boolean) => void;
+  registerHttpRoute?: (params: HttpRouteParams) => void;
+  config?: {
+    channels?: {
+      wecom?: {
+        webhookPath?: string;
+      };
+    };
+  };
   runtime?: unknown;
   [key: string]: unknown;
 }
@@ -53,7 +71,22 @@ const plugin = {
 
     api.registerChannel({ plugin: wecomPlugin });
 
-    if (api.registerHttpHandler) {
+    if (api.registerHttpRoute) {
+      const webhookPath = (api.config?.channels?.wecom?.webhookPath ?? "/wecom").trim() || "/wecom";
+      api.registerHttpRoute({
+        path: webhookPath,
+        auth: "plugin",
+        match: "prefix",
+        handler: handleWecomWebhookRequest,
+      });
+      api.registerHttpRoute({
+        path: "/wecom-media",
+        auth: "plugin",
+        match: "prefix",
+        handler: handleWecomWebhookRequest,
+      });
+    } else if (api.registerHttpHandler) {
+      // Backward compatibility for older OpenClaw core
       api.registerHttpHandler(handleWecomWebhookRequest);
     }
   },


### PR DESCRIPTION
## 背景
OpenClaw 2026.3.2 移除了 Plugin SDK 的 `api.registerHttpHandler(...)`（breaking change），导致 WeCom / WeCom App 在新 core 上 webhook 路由未注册，表现为 `/wecom`、`/wecom-app` 返回 404。

## 变更
- `extensions/wecom/index.ts`
  - 新增 `registerHttpRoute` 类型声明与 `api.config.channels.wecom.webhookPath` 读取
  - 优先使用 `api.registerHttpRoute({ path, auth: "plugin", match: "prefix", handler })` 注册
  - 额外注册 `/wecom-media` 路由（同 handler）
  - 保留 `registerHttpHandler` 分支用于旧版本 core 向后兼容

- `extensions/wecom-app/index.ts`
  - 新增 `registerHttpRoute` 类型声明与 `api.config.channels["wecom-app"].webhookPath` 读取
  - 优先使用 `registerHttpRoute` 注册 webhook
  - 保留 `registerHttpHandler` 分支用于旧版本 core 向后兼容

## 兼容性
- 新 core（2026.3.2+）：通过 `registerHttpRoute` 正常注册 HTTP webhook 路由
- 旧 core：仍走 `registerHttpHandler`，不破坏既有行为

## 本地验证（2026.3.2 环境）
- `/wecom`、`/wecom-app` 不再 404
- 路由命中后进入正常验签/解密语义（401/400），说明 webhook handler 已生效
