### PR TITLE
fix: 修复入站媒体归档跨分区(EXDEV)失败导致路径失效问题

### DIFF
--- a/extensions/wecom-app/src/api.ts
+++ b/extensions/wecom-app/src/api.ts
@@ -9,7 +9,7 @@ import {
   resolveInboundMediaKeepDays,
   resolveApiBaseUrl,
 } from "./config.js";
-import { mkdir, writeFile, unlink, rename, readdir, stat } from "node:fs/promises";
+import { mkdir, writeFile, unlink, rename, copyFile, readdir, stat } from "node:fs/promises";
 import { basename, join, extname } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -63,7 +63,21 @@ export async function finalizeInboundMedia(account: ResolvedWecomAppAccount, fil
   try {
     await rename(p, dest);
     return dest;
-  } catch {
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code ?? "";
+    if (code === "EXDEV") {
+      try {
+        await copyFile(p, dest);
+        try {
+          await unlink(p);
+        } catch {
+          // unlink 失败不影响结果，目标文件已可用
+        }
+        return dest;
+      } catch {
+        // 复制失败走下面删除行为
+      }
+    }
     // 移动失败就退化为“尽力删除”（避免 tmp 爆炸），但不抛出
     try {
       await unlink(p);

--- a/packages/shared/src/media/media-io.ts
+++ b/packages/shared/src/media/media-io.ts
@@ -647,7 +647,21 @@ export async function finalizeInboundMediaFile(
     await fsPromises.mkdir(datedDir, { recursive: true });
     await fsPromises.rename(current, target);
     return target;
-  } catch {
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code ?? "";
+    if (code === "EXDEV") {
+      try {
+        await fsPromises.copyFile(current, target);
+        try {
+          await fsPromises.unlink(current);
+        } catch {
+          // unlink 失败不影响结果，目标文件已可用
+        }
+        return target;
+      } catch {
+        return current;
+      }
+    }
     return current;
   }
 }


### PR DESCRIPTION
## 背景

在容器环境下，入站媒体文件从临时目录（如 `/tmp/wecom-app-media`）归档到持久目录（如 `/home/node/.openclaw/...`）时，`rename` 可能因跨挂载点失败并报错 `EXDEV: cross-device link not permitted`。  
这会导致归档不稳定，影响后续媒体读取与处理。

Fixes https://github.com/BytePioneer-AI/openclaw-china/issues/128

## 问题现象

- `rename(src, dest)` 在跨分区时失败（`EXDEV`）
- 归档未成功落到目标目录
- 后续流程拿到的路径可能不是最终可用路径，导致处理链路不稳定

## 本次改动

为入站媒体归档增加 `EXDEV` 兜底逻辑：

- 优先执行 `rename(src, dest)`
- 当 `code === "EXDEV"` 时，改为 `copyFile(src, dest)`，成功后尝试 `unlink(src)`
- `unlink(src)` 失败不影响主流程（目标文件已可用）

## 行为说明（按模块）

- `extensions/wecom-app/src/api.ts`
  - `EXDEV + copyFile 成功`：返回 `dest`
  - `EXDEV + copyFile 失败`：继续走原有清理逻辑（尽力 `unlink(src)`），返回原路径
  - 非 `EXDEV`：保持原行为，尽力 `unlink(src)` 后返回原路径

- `packages/shared/src/media/media-io.ts`
  - `EXDEV + copyFile 成功`：返回 `target`
  - `EXDEV + copyFile 失败`：返回原路径
  - 非 `EXDEV`：保持原行为，返回原路径

## 影响文件

- `packages/shared/src/media/media-io.ts`
- `extensions/wecom-app/src/api.ts`

## 验证

- 在跨挂载点环境复现 `EXDEV` 场景，归档可成功落盘到 `inbound/YYYY-MM-DD`
- 入站消息中的媒体路径可正常被后续流程读取