### PR TITLE
fix(qqbot): pass accountId to sendText/sendMedia/sendTyping calls

### DIFF
--- a/extensions/qqbot/src/bot.ts
+++ b/extensions/qqbot/src/bot.ts
@@ -725,8 +725,9 @@ export async function sendQQBotMediaWithFallback(params: {
   onDelivered?: () => void;
   onError?: (error: string) => void;
   outbound?: Pick<typeof qqbotOutbound, "sendMedia" | "sendText">;
+  accountId?: string;
 }): Promise<void> {
-  const { qqCfg, to, mediaQueue, replyToId, replyEventId, logger, onDelivered, onError } = params;
+  const { qqCfg, to, mediaQueue, replyToId, replyEventId, logger, onDelivered, onError, accountId } = params;
   const outbound = params.outbound ?? qqbotOutbound;
   for (const mediaUrl of mediaQueue) {
     const result = await outbound.sendMedia({
@@ -735,6 +736,7 @@ export async function sendQQBotMediaWithFallback(params: {
       mediaUrl,
       replyToId,
       replyEventId,
+      accountId,
     });
     if (result.error) {
       logger.error(`sendMedia failed: ${result.error}`);
@@ -749,6 +751,7 @@ export async function sendQQBotMediaWithFallback(params: {
         text: fallback,
         replyToId,
         replyEventId,
+        accountId,
       });
       if (fallbackResult.error) {
         logger.error(`sendText fallback failed: ${fallbackResult.error}`);
@@ -828,6 +831,7 @@ async function dispatchToAgent(params: {
       replyToId: inbound.messageId,
       replyEventId: inbound.eventId,
       inputSecond: 60,
+      accountId,
     });
     if (typing.error) {
       logger.warn(`sendTyping failed: ${typing.error}`);
@@ -871,6 +875,7 @@ async function dispatchToAgent(params: {
         text: LONG_TASK_NOTICE_TEXT,
         replyToId: inbound.messageId,
         replyEventId: inbound.eventId,
+        accountId,
       });
       if (result.error) {
         logger.warn(`send long-task notice failed: ${result.error}`);
@@ -912,6 +917,7 @@ async function dispatchToAgent(params: {
         text: buildVoiceASRFallbackReply(resolvedAttachmentResult.asrErrorMessage),
         replyToId: inbound.messageId,
         replyEventId: inbound.eventId,
+        accountId,
       });
       if (fallback.error) {
         logger.error(`sendText ASR fallback failed: ${fallback.error}`);
@@ -1107,6 +1113,7 @@ async function dispatchToAgent(params: {
             text: chunk,
             replyToId: inbound.messageId,
             replyEventId: inbound.eventId,
+            accountId,
           });
           if (result.error) {
             logger.error(`sendText failed: ${result.error}`);
@@ -1124,6 +1131,7 @@ async function dispatchToAgent(params: {
         replyToId: inbound.messageId,
         replyEventId: inbound.eventId,
         logger,
+        accountId,
         onDelivered: () => {
           markReplyDelivered();
         },


### PR DESCRIPTION
本PR由OpenClaw创建，已经由本人审核，该修改已经在本地成功运行，暂未出现后续bug，如有问题请及时评论，谢谢！

## 问题

在 QQBot 插件中，直接回复消息时 Markdown 渲染失败，但通过 `message` 工具发送的消息渲染正常。

### 根因

`bot.ts` 中的 `sendText`、`sendMedia`、`sendTyping` 调用缺少 `accountId` 参数，导致 `mergeQQBotAccountConfig` 无法正确获取账户级配置（包括 `markdownSupport`）。

### 影响

- `markdownSupport` 配置被忽略
- 多账户场景下配置混乱
- 其他依赖 `accountId` 的账户级配置也可能受影响

## 修复

为以下调用添加 `accountId` 参数：
- `qqbotOutbound.sendText()`
- `qqbotOutbound.sendMedia()`
- `qqbotOutbound.sendTyping()`
- `sendQQBotMediaWithFallback()` 函数签名

## 测试

- ✅ 私聊 Markdown 渲染正常
- ✅ 群聊 Markdown 渲染正常
- ✅ `markdownSupport: false` 配置正确生效
- ✅ 多账户配置正确读取

## 兼容性

完全向后兼容。`accountId` 参数为可选，默认值为 `DEFAULT_ACCOUNT_ID`。