### PR TITLE
feat(wecom): 收到消息后立即发送 ⏳ 确认帧

### DIFF
--- a/extensions/wecom/src/bot.ts
+++ b/extensions/wecom/src/bot.ts
@@ -38,6 +38,7 @@ import { buildWecomNativeReplyImageItem, WECOM_REPLY_MSG_ITEM_LIMIT, type WecomR
 import { consumeWecomWsPendingAutoImagePaths, registerWecomWsPendingAutoImagePaths } from "./ws-reply-context.js";
 
 export type WecomDispatchHooks = {
+  onAccepted?: () => void;
   onRouteContext?: (context: { sessionKey?: string; runId?: string }) => void;
   onChunk: (text: string) => void | Promise<void>;
   onRichChunk?: (chunk: WecomWsReplyChunk) => void | Promise<void>;
@@ -423,6 +424,11 @@ export async function dispatchWecomMessage(params: {
     accountId: account.accountId,
     peer: { kind: chatType === "group" ? "group" : "dm", id: chatId },
   });
+  try {
+    hooks.onAccepted?.();
+  } catch (err) {
+    logger.warn(`wecom accepted hook failed: ${String(err)}`);
+  }
 
   // 处理媒体文件（下载和解密）
   const mediaResult = await processMediaInMessage({

--- a/extensions/wecom/src/ws-gateway.test.ts
+++ b/extensions/wecom/src/ws-gateway.test.ts
@@ -7,7 +7,7 @@ import { WebSocketServer } from "ws";
 vi.mock("@wecom/aibot-node-sdk", async () => await import("./test-sdk-mock.js"));
 
 import { resolveWecomAccount, type PluginConfig } from "./config.js";
-import { clearWecomRuntime } from "./runtime.js";
+import { clearWecomRuntime, setWecomRuntime } from "./runtime.js";
 import {
   sendWecomWsProactiveMarkdown,
   startWecomWsGateway,
@@ -190,6 +190,239 @@ describe("wecom ws gateway", () => {
         content: "follow-up",
       })
     ).rejects.toThrow("No activated WeCom ws conversation found");
+
+    controller.abort();
+    await expect(gatewayPromise).resolves.toBeUndefined();
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+
+  it("sends a placeholder frame after acceptance and then overwrites it with the real reply", async () => {
+    const server = new WebSocketServer({ port: 0 });
+    await once(server, "listening");
+
+    const received: WecomWsFrame[] = [];
+    server.on("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const frame = JSON.parse(raw.toString()) as WecomWsFrame;
+        received.push(frame);
+        if (frame.cmd === "aibot_msg_callback" || frame.cmd === "aibot_event_callback") {
+          return;
+        }
+        socket.send(
+          JSON.stringify({
+            cmd: frame.cmd,
+            headers: {
+              req_id: frame.headers?.req_id,
+            },
+            errcode: 0,
+          })
+        );
+      });
+    });
+
+    const { port } = server.address() as AddressInfo;
+    const cfg: PluginConfig = {
+      channels: {
+        wecom: {
+          mode: "ws",
+          dmPolicy: "open",
+          botId: "bot-1",
+          secret: "secret-1",
+          wsUrl: `ws://127.0.0.1:${port}`,
+          heartbeatIntervalMs: 20,
+          reconnectInitialDelayMs: 10,
+          reconnectMaxDelayMs: 40,
+        },
+      },
+    };
+    const account = resolveWecomAccount({ cfg, accountId: "default" });
+    setWecomRuntime({
+      channel: {
+        routing: {
+          resolveAgentRoute: () => ({
+            sessionKey: "session-1",
+            accountId: account.accountId,
+          }),
+        },
+        reply: {
+          dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            await dispatcherOptions.deliver({
+              text: "final answer",
+            });
+          },
+        },
+      },
+    });
+
+    const controller = new AbortController();
+    const gatewayPromise = startWecomWsGateway({
+      cfg,
+      account,
+      abortSignal: controller.signal,
+      runtime: {
+        log: () => {},
+        error: () => {},
+      },
+    });
+
+    await waitFor(() => received.some((frame) => frame.cmd === "aibot_subscribe"));
+
+    const client = [...server.clients][0];
+    client?.send(
+      JSON.stringify({
+        cmd: "aibot_msg_callback",
+        headers: {
+          req_id: "req-placeholder-1",
+        },
+        body: {
+          msgid: "msg-placeholder-1",
+          chattype: "single",
+          from: { userid: "user-1" },
+          msgtype: "text",
+          text: { content: "hello" },
+        },
+      })
+    );
+
+    await waitFor(() =>
+      received.filter((frame) => frame.cmd === "aibot_respond_msg" && frame.body).length >= 2
+    );
+
+    const replies = received.filter((frame) => frame.cmd === "aibot_respond_msg");
+    expect(replies[0]).toMatchObject({
+      headers: { req_id: "req-placeholder-1" },
+      body: {
+        msgtype: "stream",
+        stream: {
+          finish: false,
+          content: "⏳",
+        },
+      },
+    });
+    expect(replies[1]).toMatchObject({
+      headers: { req_id: "req-placeholder-1" },
+      body: {
+        msgtype: "stream",
+        stream: {
+          finish: false,
+          content: "final answer",
+        },
+      },
+    });
+    expect(
+      (replies[0].body as { stream?: { id?: string } }).stream?.id
+    ).toBe(
+      (replies[1].body as { stream?: { id?: string } }).stream?.id
+    );
+
+    controller.abort();
+    await expect(gatewayPromise).resolves.toBeUndefined();
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+
+  it("does not send a placeholder frame when the message is rejected before dispatch", async () => {
+    const server = new WebSocketServer({ port: 0 });
+    await once(server, "listening");
+
+    const received: WecomWsFrame[] = [];
+    server.on("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const frame = JSON.parse(raw.toString()) as WecomWsFrame;
+        received.push(frame);
+        if (frame.cmd === "aibot_msg_callback" || frame.cmd === "aibot_event_callback") {
+          return;
+        }
+        socket.send(
+          JSON.stringify({
+            cmd: frame.cmd,
+            headers: {
+              req_id: frame.headers?.req_id,
+            },
+            errcode: 0,
+          })
+        );
+      });
+    });
+
+    const { port } = server.address() as AddressInfo;
+    const cfg: PluginConfig = {
+      channels: {
+        wecom: {
+          mode: "ws",
+          dmPolicy: "disabled",
+          botId: "bot-1",
+          secret: "secret-1",
+          wsUrl: `ws://127.0.0.1:${port}`,
+          heartbeatIntervalMs: 20,
+          reconnectInitialDelayMs: 10,
+          reconnectMaxDelayMs: 40,
+        },
+      },
+    };
+    const account = resolveWecomAccount({ cfg, accountId: "default" });
+    setWecomRuntime({
+      channel: {
+        routing: {
+          resolveAgentRoute: () => ({
+            sessionKey: "session-1",
+            accountId: account.accountId,
+          }),
+        },
+        reply: {
+          dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
+            await dispatcherOptions.deliver({
+              text: "should not happen",
+            });
+          },
+        },
+      },
+    });
+
+    const controller = new AbortController();
+    const gatewayPromise = startWecomWsGateway({
+      cfg,
+      account,
+      abortSignal: controller.signal,
+      runtime: {
+        log: () => {},
+        error: () => {},
+      },
+    });
+
+    await waitFor(() => received.some((frame) => frame.cmd === "aibot_subscribe"));
+
+    const client = [...server.clients][0];
+    client?.send(
+      JSON.stringify({
+        cmd: "aibot_msg_callback",
+        headers: {
+          req_id: "req-disabled-1",
+        },
+        body: {
+          msgid: "msg-disabled-1",
+          chattype: "single",
+          from: { userid: "user-1" },
+          msgtype: "text",
+          text: { content: "hello" },
+        },
+      })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(received.filter((frame) => frame.cmd === "aibot_respond_msg")).toHaveLength(0);
 
     controller.abort();
     await expect(gatewayPromise).resolves.toBeUndefined();

--- a/extensions/wecom/src/ws-gateway.ts
+++ b/extensions/wecom/src/ws-gateway.ts
@@ -13,6 +13,7 @@ import {
   registerWecomWsEventContext,
   registerWecomWsMessageContext,
   scheduleWecomWsMessageContextFinish,
+  sendWecomWsMessagePlaceholder,
 } from "./ws-reply-context.js";
 import { normalizeWecomWsCallback, type WecomWsFrame } from "./ws-protocol.js";
 
@@ -359,7 +360,6 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
         accountId: account.accountId,
         reqId: callback.reqId,
         to: callback.target,
-        initialAck: "⏳",
         send: async (replyFrame) => {
           await sendSdkReplyFrame({
             client,
@@ -380,6 +380,15 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
         msg: callback.msg,
         core,
         hooks: {
+          onAccepted: () => {
+            void sendWecomWsMessagePlaceholder({
+              accountId: account.accountId,
+              reqId: callback.reqId,
+              content: "⏳",
+            }).catch((err) => {
+              logger.warn(`wecom ws placeholder ack failed: ${String(err)}`);
+            });
+          },
           onRouteContext: (context) => {
             bindWecomWsRouteContext({
               accountId: account.accountId,

--- a/extensions/wecom/src/ws-reply-context.test.ts
+++ b/extensions/wecom/src/ws-reply-context.test.ts
@@ -10,6 +10,7 @@ import {
   registerWecomWsEventContext,
   registerWecomWsMessageContext,
   registerWecomWsPendingAutoImagePaths,
+  sendWecomWsMessagePlaceholder,
   sendWecomWsActiveTemplateCard,
 } from "./ws-reply-context.js";
 
@@ -181,6 +182,69 @@ describe("wecom ws reply context", () => {
           id: "stream-2",
           finish: true,
           content: "partial answer\n\nError: upstream failed",
+        },
+      },
+    });
+  });
+
+  it("sends a placeholder frame that gets overwritten by the first real chunk", async () => {
+    const sent: unknown[] = [];
+    registerWecomWsMessageContext({
+      accountId: "acc-1",
+      reqId: "req-placeholder",
+      to: "user:alice",
+      send: async (frame) => {
+        sent.push(frame);
+      },
+      streamId: "stream-placeholder",
+    });
+
+    await expect(
+      sendWecomWsMessagePlaceholder({
+        accountId: "acc-1",
+        reqId: "req-placeholder",
+        content: "⏳",
+      })
+    ).resolves.toBe(true);
+
+    await expect(
+      appendWecomWsActiveStreamChunk({
+        accountId: "acc-1",
+        to: "user:alice",
+        chunk: "final answer",
+      })
+    ).resolves.toBe(true);
+
+    await finishWecomWsMessageContext({
+      accountId: "acc-1",
+      reqId: "req-placeholder",
+    });
+
+    expect(sent).toHaveLength(3);
+    expect(sent[0]).toMatchObject({
+      body: {
+        stream: {
+          id: "stream-placeholder",
+          finish: false,
+          content: "⏳",
+        },
+      },
+    });
+    expect(sent[1]).toMatchObject({
+      body: {
+        stream: {
+          id: "stream-placeholder",
+          finish: false,
+          content: "final answer",
+        },
+      },
+    });
+    expect(sent[2]).toMatchObject({
+      body: {
+        stream: {
+          id: "stream-placeholder",
+          finish: true,
+          content: "final answer",
         },
       },
     });

--- a/extensions/wecom/src/ws-reply-context.ts
+++ b/extensions/wecom/src/ws-reply-context.ts
@@ -245,7 +245,6 @@ export function registerWecomWsMessageContext(params: {
   to: string;
   send: WsSendFrame;
   streamId?: string;
-  initialAck?: string;
 }): string {
   pruneContexts();
   const key = messageKey(params.accountId.trim(), params.reqId.trim());
@@ -267,21 +266,34 @@ export function registerWecomWsMessageContext(params: {
   };
   messageContexts.set(key, context);
   addTargetIndex(messageByTarget, targetKey(context.accountId, context.to), key);
-  if (params.initialAck) {
-    const ack = params.initialAck;
-    void enqueue(context, async () => {
-      await context.send(
-        buildWecomWsRespondMessageCommand({
-          reqId: context.reqId,
-          streamId: context.streamId,
-          content: ack,
-          finish: false,
-        })
-      );
-      context.started = true;
-    });
-  }
   return context.streamId;
+}
+
+export async function sendWecomWsMessagePlaceholder(params: {
+  accountId: string;
+  reqId: string;
+  content: string;
+}): Promise<boolean> {
+  pruneMessageContexts();
+  const key = messageKey(params.accountId.trim(), params.reqId.trim());
+  const context = messageContexts.get(key);
+  const content = params.content.trim();
+  if (!context || context.finished || context.started || !content) return false;
+
+  await enqueue(context, async () => {
+    if (context.finished || context.started) return;
+    await context.send(
+      buildWecomWsRespondMessageCommand({
+        reqId: context.reqId,
+        streamId: context.streamId,
+        content,
+        finish: false,
+      })
+    );
+    context.started = true;
+    context.updatedAt = now();
+  });
+  return true;
 }
 
 export function registerWecomWsEventContext(params: {


### PR DESCRIPTION
用户通过企业微信发消息给 openclaw 时，如果 agent 需要进行大量工具调用，用户会一直等待却没有任何反馈。                                                                                                                                                                        
│ 目标：收到消息后立即发送 "⏳" 确认帧，AI 开始回复时自动替换（快照式流式协议，每帧替换前帧）。

工作原理（完整流程）                                                                                                                                                                                                                                                         
│ 1. 消息到达 → 创建 context（content: "", started: false）                                                                                                                                                                                                                    
│ 2. ack 任务进入 context.queue → 发送 {finish: false, content: "⏳"} → context.started = true                                                                                                                                                                                 
│ 3. 用户立即看到 "⏳"                                                                                                                                                                                                                                                         
│ 4. AI 生成第一个 chunk → appendStreamSnapshotContent("", chunk) = chunk（直接替换 ⏳）                                                                                                                                                                                       
│ 5. AI chunk 任务排在 ack 之后进入队列，顺序有保障                                                                                                                                                                                                                            
│ 6. 最终 finishWecomWsMessageContext 发送 {finish: true, content: 完整回复}

要修改的文件                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
│ 文件 1：extensions/wecom/src/ws-reply-context.ts（第 242 行）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
│ 文件 2：extensions/wecom/src/ws-gateway.ts（第 358 行）