### PR TITLE
feat: 优化QQBot Markdown传输和日志输出

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@
 <details>
 <summary><strong>点击展开更新日志</strong></summary>
 
+### 2026-03-12
+- `qqbot` 调整 QQ 私聊 C2C Markdown transport：在开启 `/verbose on` 且 `replyFinalOnly=false` 时，非 final 的工具/日志输出恢复为即时发送，一个日志一条消息，不再合并到最终回复里。
+- `qqbot` 保持 `replyFinalOnly=true` 的既有语义：非 final 纯文本输出继续被抑制，但媒体类工具结果仍可正常投递。
+
 ### 2026-03-11
 - `qqbot` 调整 C2C Markdown transport：私聊 Markdown 回复现在保留原始 Markdown 文本，公网图片自动补 QQ 图片尺寸语法，本地图片继续走富媒体 API。
 - `qqbot` 新增 `c2cMarkdownDeliveryMode` 的整条回复级主动/被动策略说明；对于“带表格后标题、引用、任务列表等 Markdown 不稳定”的场景，推荐直接使用 `proactive-all`。
@@ -431,6 +435,8 @@ openclaw config set channels.qqbot.c2cMarkdownDeliveryMode proactive-all
 - `proactive-table-only`：仅当回复里出现 Markdown 表格时，整条 C2C 回复改走主动发送
 - `proactive-all`：所有 C2C Markdown 回复统一改走主动发送
 - C2C 主动 Markdown transport 会尽量保留原始 Markdown，并默认整条单消息发送；只有超出长度限制时才继续分块
+- 在 QQ 私聊启用 Markdown transport（`markdownSupport=true`）后，开启 `/verbose on` 且 `replyFinalOnly=false` 时，非 final 的工具/日志输出会即时回发，一个日志一个消息
+- 如果同时开启 `replyFinalOnly=true`，非 final 纯文本日志仍会被抑制，只保留最终回复；媒体类工具结果不受影响
 - 如果你发现“不带表格时基本正常，但带表格后标题、引用、任务列表不稳定”，优先使用 `proactive-all`；这通常是 QQ 被动回复接口本身的渲染限制
 
 主动发送与已知目标：

--- a/doc/guides/qqbot/configuration.md
+++ b/doc/guides/qqbot/configuration.md
@@ -143,7 +143,7 @@ openclaw config set gateway.http.endpoints.chatCompletions.enabled true
 | allowFrom | string[] | [] | 私聊白名单 |
 | groupAllowFrom | string[] | [] | 群聊白名单 |
 | textChunkLimit | number | 1500 | 文本分块长度；C2C Markdown transport 默认尽量保持整条单消息发送，仅在超过长度限制时才分块 |
-| replyFinalOnly | boolean | false | 是否仅发送最终回复文本（不会阻断媒体工具结果，如 TTS 语音） |
+| replyFinalOnly | boolean | false | 是否仅发送最终回复文本；开启后会抑制非 final 的纯文本日志/工具输出，但不会阻断媒体工具结果（如 TTS 语音） |
 | c2cMarkdownDeliveryMode | string | "proactive-table-only" | 私聊 C2C Markdown transport 发送策略：`passive` 保持整条回复走被动接口，`proactive-table-only` 在回复中检测到 Markdown 表格时让整条回复改走主动接口，`proactive-all` 让所有私聊 Markdown 回复统一走主动接口 |
 | autoSendLocalPathMedia | boolean | true | 是否自动把回复文本中的本地图片路径识别为媒体并发送；设为 `false` 时，类似 `/root/.openclaw/media/qqbot/inbound/...jpeg` 的路径会保留在文本里，适合展示“证据 / 文件路径：...” |
 | longTaskNoticeDelayMs | number | 30000 | 首条正式回复超过该时长仍未发送时，自动补发“任务处理时间较长，请稍等，我还在继续处理。”；设为 `0` 可关闭 |
@@ -169,7 +169,7 @@ openclaw config set channels.qqbot.autoSendLocalPathMedia false
 - `autoSendLocalPathMedia=true`：裸本地图片路径会自动作为媒体发送
 - `autoSendLocalPathMedia=false`：裸本地图片路径保留为文本
 - 显式 `MEDIA:` 指令仍会继续按媒体发送
-- 
+
 ### 3.1 私聊 Markdown 渲染策略
 
 如需通过配置控制 QQ 私聊的 Markdown 发送方式，可以设置：
@@ -182,8 +182,27 @@ openclaw config set channels.qqbot.c2cMarkdownDeliveryMode proactive-all
 
 - `passive`：整条 C2C Markdown 回复保持被动发送，Markdown 文本和本地富媒体都会保留 `replyToId/replyEventId`
 - `proactive-table-only`：当最终回复里包含 Markdown 表格时，整条 C2C 回复统一改走主动发送
-- `proactive-all`：所有 C2C Markdown 回复统一在回复结束后走主动发送，适合兼容标题、引用、分割线、表格等渲染问题
-  
+- `proactive-all`：所有 C2C Markdown 回复统一走主动发送，适合兼容标题、引用、分割线、表格等渲染问题
+
+补充说明：
+
+- 在 QQ 私聊启用 Markdown transport（`markdownSupport=true`）后，默认 `replyFinalOnly=false` 时，`/verbose on` 产生的非 final 文本日志会即时发送，一个日志一个消息，不再合并到最终回复中
+- 如果开启 `replyFinalOnly=true`，非 final 纯文本日志仍会被抑制，只保留最终回复；带媒体的工具结果仍会照常发送
+
+### 3.2 验证 `/verbose on` 实时输出
+
+建议在升级后做一次快速自检：
+
+1. 在 QQ 私聊里发送 `/verbose on`
+2. 再发送一个会触发工具调用、长任务或文件处理的请求
+3. 观察回包是否符合预期
+
+预期结果：
+
+- `replyFinalOnly=false`：verbose/tool 日志会按处理过程逐条回发，一个日志一个消息
+- 最终答复仍会单独发送，不会把前面的日志重新合并
+- `replyFinalOnly=true`：非 final 纯文本日志不会单独发送，但媒体类工具结果仍可投递
+
 ### 4. 多账户配置
 
 如需配置多个 QQ 机器人，可以使用 `accounts` 对象（键为账户 ID）：
@@ -238,7 +257,7 @@ openclaw config set channels.qqbot.c2cMarkdownDeliveryMode proactive-all
 - 当前实现支持文本消息收发与图片发送（C2C/群聊）
 - QQ C2C/群聊富媒体接口暂不支持通用文件（`file_type=4`，例如 PDF），这是官方接口限制而非插件缺陷，会降级为文本提示
 - 频道内暂不支持媒体发送（会降级为文本 + URL）
-- 不支持平台级流式输出
+- 不支持平台级流式输出；但 QQ 私聊在启用 Markdown transport 且 `replyFinalOnly=false` 时，可以按消息逐条回发非 final verbose/tool 日志
 - 定时提醒通过 OpenClaw cron 触发（无需额外配置）
 - 插件会自动记录通过策略校验的已知目标，供主动发送脚本复用
 

--- a/extensions/qqbot/src/bot.c2c-markdown-transport.test.ts
+++ b/extensions/qqbot/src/bot.c2c-markdown-transport.test.ts
@@ -189,7 +189,7 @@ describe("QQBot C2C markdown transport", () => {
     ).toBe(true);
     expect(
       logger.info.mock.calls.some(([message]) =>
-        String(message).includes('delivery=c2c-markdown-proactive segment=1/1 chunk=1/1 preview=')
+        String(message).includes('delivery=c2c-markdown-proactive segment=1/1 chunk=1/1 phase=immediate preview=')
       )
     ).toBe(true);
   });
@@ -243,6 +243,52 @@ describe("QQBot C2C markdown transport", () => {
       replyToId: undefined,
       replyEventId: undefined,
     });
+  });
+
+  it("sends verbose non-final c2c markdown payloads immediately instead of merging them", async () => {
+    installReplyRuntime([
+      { text: "✉️ Message", kind: "tool" },
+      { text: "🧹 Auto-compaction complete (count 8).", kind: "tool" },
+      { text: "我把这张图重新发你一遍。", kind: "final" },
+    ]);
+    const logger = createLogger();
+
+    await handleQQBotDispatch({
+      eventType: "C2C_MESSAGE_CREATE",
+      eventData: {
+        id: "msg-verbose-1",
+        event_id: "evt-verbose-1",
+        content: "hello",
+        timestamp: 1700000000002,
+        author: {
+          user_openid: "u-verbose-1",
+          username: "Alice",
+        },
+      },
+      cfg: {
+        channels: {
+          qqbot: {
+            ...baseCfg.channels.qqbot,
+            c2cMarkdownDeliveryMode: "proactive-all",
+          },
+        },
+      },
+      accountId: "default",
+      logger,
+    });
+
+    expect(outboundMocks.sendText).toHaveBeenCalledTimes(3);
+    expect(outboundMocks.sendText.mock.calls.map((call) => call[0]?.text)).toEqual([
+      "✉️ Message",
+      "🧹 Auto-compaction complete (count 8).",
+      "我把这张图重新发你一遍。",
+    ]);
+    expect(
+      logger.info.mock.calls.some(([message]) =>
+        String(message).includes("delivery=c2c-markdown-proactive") &&
+        String(message).includes("phase=immediate")
+      )
+    ).toBe(true);
   });
 
   it("keeps raw markdown for c2c transport even when framework table conversion is enabled", async () => {

--- a/extensions/qqbot/src/bot.ts
+++ b/extensions/qqbot/src/bot.ts
@@ -1454,32 +1454,20 @@ async function dispatchToAgent(params: {
       bufferedC2CMarkdownMediaUrls.push(next);
     };
 
-    const flushBufferedC2CMarkdownReply = async (): Promise<void> => {
-      if (
-        !useC2CMarkdownTransport ||
-        (bufferedC2CMarkdownTexts.length === 0 && bufferedC2CMarkdownMediaUrls.length === 0)
-      ) {
-        bufferedC2CMarkdownTexts = [];
-        bufferedC2CMarkdownMediaUrls = [];
-        bufferedC2CMarkdownMediaSeen.clear();
-        return;
-      }
-
-      const combinedText = bufferedC2CMarkdownTexts.join("\n\n").trim();
-      const combinedMediaUrls = [...bufferedC2CMarkdownMediaUrls];
-      bufferedC2CMarkdownTexts = [];
-      bufferedC2CMarkdownMediaUrls = [];
-      bufferedC2CMarkdownMediaSeen.clear();
-
-      const normalizedCombinedText = normalizeQQBotRenderedMarkdown(combinedText);
-      const { markdownImageUrls, mediaQueue } = splitQQBotMarkdownTransportMediaUrls(combinedMediaUrls);
+    const sendC2CMarkdownTransportPayload = async (params: {
+      text: string;
+      mediaUrls: string[];
+      phase: "buffered" | "immediate";
+    }): Promise<void> => {
+      const normalizedText = normalizeQQBotRenderedMarkdown(params.text);
+      const { markdownImageUrls, mediaQueue } = splitQQBotMarkdownTransportMediaUrls(params.mediaUrls);
       const finalMarkdownText = await normalizeQQBotMarkdownImages({
-        text: normalizedCombinedText,
+        text: normalizedText,
         appendImageUrls: markdownImageUrls,
       });
       const textReplyRefs = resolveQQBotTextReplyRefs({
         to: target.to,
-        text: finalMarkdownText || normalizedCombinedText,
+        text: finalMarkdownText || normalizedText,
         markdownSupport,
         c2cMarkdownDeliveryMode,
         replyToId: inbound.messageId,
@@ -1492,7 +1480,7 @@ async function dispatchToAgent(params: {
       logger.info(
         `delivery=${deliveryLabel} to=${target.to} segments=${textSegments.length} media=${mediaQueue.length} ` +
           `replyToId=${textReplyRefs.replyToId ? "yes" : "no"} replyEventId=${textReplyRefs.replyEventId ? "yes" : "no"} ` +
-          `tableMode=${String(resolvedTableMode)} chunkMode=${String(chunkMode ?? "default")}`
+          `phase=${params.phase} tableMode=${String(resolvedTableMode)} chunkMode=${String(chunkMode ?? "default")}`
       );
 
       await sendQQBotMediaWithFallback({
@@ -1522,7 +1510,8 @@ async function dispatchToAgent(params: {
           const chunk = chunks[chunkIndex] ?? "";
           logger.info(
             `delivery=${deliveryLabel} segment=${segmentIndex + 1}/${textSegments.length} ` +
-              `chunk=${chunkIndex + 1}/${chunks.length} preview=${formatQQBotOutboundPreview(chunk)}`
+              `chunk=${chunkIndex + 1}/${chunks.length} phase=${params.phase} ` +
+              `preview=${formatQQBotOutboundPreview(chunk)}`
           );
           const result = await qqbotOutbound.sendText({
             cfg: { channels: { qqbot: qqCfg } },
@@ -1533,14 +1522,38 @@ async function dispatchToAgent(params: {
             accountId: outboundAccountId,
           });
           if (result.error) {
-            logger.error(`send buffered QQ markdown reply failed: ${result.error}`);
+            logger.error(`send QQ markdown reply failed: ${result.error}`);
             markGroupMessageInterfaceBlocked(result.error);
           } else {
-            logger.info(`sent buffered QQ markdown reply (len=${chunk.length})`);
+            logger.info(`sent QQ markdown reply (phase=${params.phase}, len=${chunk.length})`);
             markReplyDelivered();
           }
         }
       }
+    };
+
+    const flushBufferedC2CMarkdownReply = async (): Promise<void> => {
+      if (
+        !useC2CMarkdownTransport ||
+        (bufferedC2CMarkdownTexts.length === 0 && bufferedC2CMarkdownMediaUrls.length === 0)
+      ) {
+        bufferedC2CMarkdownTexts = [];
+        bufferedC2CMarkdownMediaUrls = [];
+        bufferedC2CMarkdownMediaSeen.clear();
+        return;
+      }
+
+      const combinedText = bufferedC2CMarkdownTexts.join("\n\n").trim();
+      const combinedMediaUrls = [...bufferedC2CMarkdownMediaUrls];
+      bufferedC2CMarkdownTexts = [];
+      bufferedC2CMarkdownMediaUrls = [];
+      bufferedC2CMarkdownMediaSeen.clear();
+
+      await sendC2CMarkdownTransportPayload({
+        text: combinedText,
+        mediaUrls: combinedMediaUrls,
+        phase: "buffered",
+      });
     };
 
     const deliver = async (payload: unknown, info?: { kind?: string }): Promise<void> => {
@@ -1586,13 +1599,24 @@ async function dispatchToAgent(params: {
       const textToSend = suppressText ? "" : cleanedText;
 
       if (useC2CMarkdownTransport) {
-        if (textToSend) {
-          bufferedC2CMarkdownTexts = appendQQBotBufferedText(bufferedC2CMarkdownTexts, textToSend);
+        const shouldBufferFinalOnlyPayload = replyFinalOnly && (!info?.kind || info.kind === "final");
+
+        if (shouldBufferFinalOnlyPayload) {
+          if (textToSend) {
+            bufferedC2CMarkdownTexts = appendQQBotBufferedText(bufferedC2CMarkdownTexts, textToSend);
+          }
+
+          for (const url of mediaQueue) {
+            bufferC2CMarkdownMedia(url);
+          }
+          return;
         }
 
-        for (const url of mediaQueue) {
-          bufferC2CMarkdownMedia(url);
-        }
+        await sendC2CMarkdownTransportPayload({
+          text: textToSend,
+          mediaUrls: mediaQueue,
+          phase: "immediate",
+        });
         return;
       }
 


### PR DESCRIPTION
- 调整QQBot在私聊中Markdown的即时发送逻辑，确保非最终的工具/日志输出能够即时发送。
- 更新配置说明，明确`replyFinalOnly`的行为，确保用户理解其对日志输出的影响。
- 增加测试用例，验证非最终消息的即时发送功能，确保符合预期。

修改文件:
- README.md
- doc/guides/qqbot/configuration.md
- extensions/qqbot/src/bot.c2c-markdown-transport.test.ts
- extensions/qqbot/src/bot.ts