### PR TITLE
fix(qqbot): 恢复 C2C 流式回复中 assistant 过渡消息与工具日志的交错发送

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@
 |------|:----:|:----:|:--:|:------------------:|:----------------:|
 | 文本消息 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Markdown | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 流式响应 | ✅ | - | ❌ | ✅ | ❌ |
+| 流式响应 | ✅ | - | ⚠️<br />私聊实时分条回发 | ✅ | ❌ |
 | 图片/文件 | ✅  | ✅<br />（仅发送） | ✅<br />（出站：私聊任意类型， 群聊仅图片） | ✅（出站文件受限） | ✅<br />（出站任意类型；入站允许图片、音视频、定位、语音） |
 | 语音消息 | ✅ | - | ✅ | ✅ | ✅ |
 | 私聊 | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -116,17 +116,24 @@
 | 连接方式 | Stream | WebSocket | - | WebSocket 长连接 | HTTPS 回调 |
 | Access Token 缓存 | - | - | - | - | ✅（2 小时有效期） |
 
+> 说明：QQ 不支持平台原生 token 级流式输出，但在私聊里配合 `replyFinalOnly=false` 与 `/verbose on` 时，assistant 过渡说明和 tool 日志会按真实生成顺序分条实时回发。
+
 ## 更新日志
 
 <details>
 <summary><strong>点击展开更新日志</strong></summary>
 
+### 2026-03-14
+- `qqbot` 新增私聊用户显示名别名映射 `displayAliases`。首期仅对 direct 用户生效，支持 `user:<openid>`、`<openid>`、`senderId` 等键名，方便按已有联系人信息覆盖默认显示名。
+- `qqbot` 现在会优先使用 `~/.openclaw/qqbot/data/known-targets.json` 里的 `displayName` 作为私聊用户显示名；如果没有，再回退到 `displayAliases`，最后才使用稳定 ID，减少多账号和备注名场景下的识别成本。
+- `qqbot` 新增内置 `qqbot-contact-send` skill，并会随插件自动注册到新会话的 `<available_skills>`。模型可直接基于 `known-targets.json` 按联系人备注/显示名解析发送对象，并默认优先使用当前会话的 `accountId` 过滤目标，降低误发给同名联系人的风险。
+- `qqbot` 在 QQ 私聊里开启 `/verbose on` 且 `replyFinalOnly=false` 后，assistant 的普通过渡说明和工具日志现在都会实时发送，并按真实生成顺序交错出现，不会再出现“日志先刷完、说明最后补发”的时序错乱。
+- 这次修复只影响 QQ 私聊/C2C 的实时回发路径；如果你保持 `replyFinalOnly=true`，行为仍然和以前一样，只发最终文本结果，媒体结果不受影响。
+
 ### 2026-03-13
 - `qqbot` 现在能看懂 QQ 私聊里的“引用上一条消息”。用户问“这个是什么”“你刚才说的哪个文件”时，模型会一起参考被引用的那条内容来回答。
 - 引用内容会自动缓存在本地 `~/.openclaw/qqbot/data/ref-index.jsonl`，就算网关重启，之前的引用关系也还能继续识别。
 - 被引用的内容不只支持纯文本，也支持图片、语音、视频、文件这类消息的摘要；如果本地确实找不到旧消息，也不会再把“原始内容不可用”这种占位词喂给模型。
-- `qqbot` 新增内置 `qqbot-contact-send` skill，支持基于 `~/.openclaw/qqbot/data/known-targets.json` 按联系人备注/显示名解析发送对象，并默认优先使用当前会话的 `accountId` 过滤目标，减少多账号场景下误发给同名联系人。
-- 这个 skill 现在会随 QQBot 插件自动注册到新会话的 `<available_skills>`，模型可直接利用它生成 `message` tool 所需的发送参数，不需要再手工复制到 workspace 或 `~/.openclaw/skills`；正式安装的 npm 包也会一并带上对应 skill 文件和脚本。
 
 ### 2026-03-12
 - `qqbot` 在 QQ 私聊里开启 `/verbose on` 且 `replyFinalOnly=false` 后，执行过程中的工具输出和日志会边跑边发，一条一条实时出现，不会再等到最后一起发。

--- a/doc/guides/qqbot/configuration.md
+++ b/doc/guides/qqbot/configuration.md
@@ -152,7 +152,7 @@ openclaw config set gateway.http.endpoints.chatCompletions.enabled true
 | allowFrom | string[] | [] | 私聊白名单；只有在 `dmPolicy=allowlist` 时才需要配 |
 | groupAllowFrom | string[] | [] | 群聊白名单；只有在 `groupPolicy=allowlist` 时才需要配 |
 | textChunkLimit | number | 1500 | 单条消息允许的最大文本长度；超出后会自动拆成多条 |
-| replyFinalOnly | boolean | false | 是否只发最终答案。开启后，中间过程日志不发，但图片、语音这类媒体结果仍可正常发送 |
+| replyFinalOnly | boolean | false | 是否只发最终答案。`false` 时，QQ 私聊配合 `/verbose on` 会把 assistant 过渡说明和 tool 日志按真实顺序实时分条回发；`true` 时不发普通中间文本，但图片、语音这类媒体结果仍可正常发送 |
 | c2cMarkdownDeliveryMode | string | "proactive-table-only" | QQ 私聊里 Markdown 用什么方式发。默认只在“带表格”时切到更稳的方式；如果格式老是乱，可以改成 `proactive-all` |
 | autoSendLocalPathMedia | boolean | true | 是否把回复里的本地图片路径自动当成图片发出去。关掉后，路径会原样保留在文本里 |
 | longTaskNoticeDelayMs | number | 30000 | 多久还没正式回复，就先补一句“我还在处理”。设为 `0` 可关闭 |
@@ -217,12 +217,14 @@ openclaw config set channels.qqbot.c2cMarkdownDeliveryMode proactive-all
 - `proactive-table-only`：默认值。平时按普通方式发，只有检测到表格时才切到更稳的方式
 - `proactive-all`：所有私聊 Markdown 都走更稳的方式发。如果你经常遇到标题、引用、分割线、表格显示不对，优先试这个
 
-补充说明：
+### 3.2 私聊实时回发语义
 
-- 默认 `replyFinalOnly=false` 时，`/verbose on` 产生的中间日志会实时一条一条发出
-- 如果你把 `replyFinalOnly=true` 打开，普通中间日志就不发了，只保留最终答案；媒体结果不受影响
+- 默认 `replyFinalOnly=false` 时，QQ 私聊里的 assistant 过渡说明和 tool/verbose 日志都会实时发出，并按真实生成顺序交错出现
+- 你应该看到“说明 -> 日志 -> 说明 -> 日志”这类自然交错，而不是所有日志先发完、最后再补说明
+- 如果你把 `replyFinalOnly=true` 打开，普通中间文本就不发了，只保留最终答案；媒体结果不受影响
+- 这套实时回发语义当前只覆盖 QQ 私聊/C2C，群聊和频道仍保持现有行为
 
-### 3.2 验证 `/verbose on` 实时输出
+### 3.3 验证 `/verbose on` 实时输出
 
 建议在升级后做一次快速自检：
 
@@ -232,7 +234,8 @@ openclaw config set channels.qqbot.c2cMarkdownDeliveryMode proactive-all
 
 预期结果：
 
-- `replyFinalOnly=false`：verbose/tool 日志会按处理过程逐条回发，一个日志一个消息
+- `replyFinalOnly=false`：assistant 过渡说明、verbose/tool 日志都会按处理过程逐条回发，顺序和实际生成顺序一致
+- 你会看到说明消息和工具日志自然交错，而不是“工具日志先刷完，说明类消息最后补发”
 - 最终答复仍会单独发送，不会把前面的日志重新合并
 - `replyFinalOnly=true`：非 final 纯文本日志不会单独发送，但媒体类工具结果仍可投递
 
@@ -312,7 +315,7 @@ openclaw daemon start
 - 支持文本消息、图片、语音和部分文件能力；其中私聊能力比群聊更完整
 - QQ 官方接口对媒体能力本身有限制，尤其是群聊和频道，所以有些文件类型会自动降级成“文本提示 + 链接/路径”
 - 频道消息暂不支持直接发媒体，会退回成文本 + URL
-- QQ 本身不支持真正的平台级流式输出；但在私聊里可以通过多条消息的方式把中间过程持续发出来
+- QQ 本身不支持真正的平台级 token 流式输出；但在私聊里可以通过多条消息的方式，把 assistant 过渡说明和工具过程实时交错发出来
 - 私聊支持识别“引用上一条消息”，引用内容默认从 `~/.openclaw/qqbot/data/ref-index.jsonl` 恢复
 - 定时提醒直接走 OpenClaw 自带 cron，不需要额外接别的服务
 - 插件会自动记录通过策略校验的已知用户/群，方便后面主动发送时直接复用


### PR DESCRIPTION
## Summary

本次改动修复了 QQBot 在私聊/C2C 流式回复中的一处时序问题。

此前为了解决“工具日志会延后发送”的问题，QQBot 开始优先接入更直接的 reply dispatcher；但在真实运行环境中，assistant 的普通过渡消息实际走的是 block reply 通道，而该通道仍处于关闭状态，结果变成了“工具日志能实时发送，但 assistant 过渡消息完全不发”。

这次 PR 在保留 direct dispatcher 的前提下，显式为 QQBot C2C 流式回复开启 block streaming，使 assistant 过渡消息与 tool log 能按真实生成顺序交错下发。

## Background

近期 QQBot 已对 C2C Markdown transport 和 verbose 日志输出做过优化，目标是让非 final 的工具输出尽量实时发送。

这次修复确认了一个更细的行为差异：

- tool 日志通过 `tool` 通道发送
- assistant 普通过渡消息通过 `block` 通道发送
- direct dispatcher 本身不会丢弃 `block`
- 但如果 `disableBlockStreaming` 没有明确关闭，`block` 通道在运行时仍可能被抑制

因此，单纯切换 dispatcher 还不够，必须同时为 QQBot 的 C2C 流式路径显式打开 block streaming，assistant 过渡消息才能真正出现在用户侧。

## Changes

- 在 `extensions/qqbot/src/bot.ts` 中为 QQBot C2C 且 `replyFinalOnly=false` 的场景优先使用 `dispatchReplyWithDispatcher`
- 在同一路径下显式传入 `replyOptions.disableBlockStreaming = false`，确保 assistant `block` reply 不再被运行时吞掉
- 保留现有 buffered 和 legacy dispatcher 作为兼容回退路径，未改变 group/channel 的发送策略
- 为不同分发路径增加调试日志，便于区分当前实际走的是 `direct`、`buffered` 还是 `legacy`
- 在 `extensions/qqbot/src/runtime.ts` 中补充 `dispatchReplyWithDispatcher` 的类型声明
- 在 `extensions/qqbot/src/channel.ts` 中放宽 runtime 注入条件，允许仅暴露 direct dispatcher 的运行时完成初始化

测试覆盖同步更新：

- `bot.regressions.test.ts` 新增 direct dispatcher 回归用例，验证 assistant 说明与 tool 日志保持交错顺序，并断言传入了 `disableBlockStreaming: false`
- `bot.c2c-markdown-transport.test.ts` 扩展 verbose C2C Markdown transport 用例，覆盖 assistant `block` 与 tool `tool` 混合输出顺序
- `channel.test.ts` 新增 runtime 初始化测试，覆盖只提供 direct dispatcher 的运行时场景

## Impact

行为变化范围明确限制在 QQBot 私聊/C2C 流式回复路径：

- 仅当目标为 C2C 且 `replyFinalOnly=false` 时，assistant 过渡消息会和工具日志一起按生成顺序实时发送
- `replyFinalOnly=true` 的语义保持不变，本次没有放宽“仅保留最终纯文本回复”的既有约束
- group/channel 回复路径不受影响
- buffered / legacy 路径仍保留，不要求部署环境必须立即具备 direct dispatcher 才能运行

兼容性方面，本次没有新增配置项，也没有修改已有配置字段语义；改动主要集中在运行时能力识别、reply dispatcher 选择和 C2C block streaming 的显式开启。

## Testing

已完成以下验证：

- `pnpm -C extensions/qqbot test -- src/bot.regressions.test.ts src/bot.c2c-markdown-transport.test.ts`
  - 2 个测试文件，13 个测试全部通过
- `pnpm -C extensions/qqbot test`
  - 18 个测试文件，137 个测试全部通过
- `pnpm -C extensions/qqbot build`
  - 构建成功

说明：

- 构建过程中仍有既存的 unused import 警告（`readdirSync` / `lstatSync`、`ReadStream`、`stripVTControlCharacters`），但不影响本次修复构建通过
