### PR TITLE
fix(wecom): harden ws shutdown cleanup

### DIFF
--- a/extensions/wecom/src/test-sdk-mock.ts
+++ b/extensions/wecom/src/test-sdk-mock.ts
@@ -19,6 +19,16 @@ type PendingResolver = {
   reject: (err: Error) => void;
 };
 
+let mockDisconnectErrorMessage: string | null = null;
+
+export function setMockDisconnectErrorMessage(message: string | null): void {
+  mockDisconnectErrorMessage = message?.trim() ? message : null;
+}
+
+export function resetMockSdkBehavior(): void {
+  mockDisconnectErrorMessage = null;
+}
+
 export class WSClient extends EventEmitter {
   private readonly botId: string;
   private readonly secret: string;
@@ -111,6 +121,11 @@ export class WSClient extends EventEmitter {
 
   disconnect(): void {
     this.clearHeartbeat();
+    if (mockDisconnectErrorMessage) {
+      queueMicrotask(() => {
+        this.emit("error", new Error(mockDisconnectErrorMessage ?? "mock disconnect error"));
+      });
+    }
     this.socket?.close();
     this.socket = null;
   }

--- a/extensions/wecom/src/ws-gateway.test.ts
+++ b/extensions/wecom/src/ws-gateway.test.ts
@@ -6,6 +6,7 @@ import { WebSocketServer } from "ws";
 
 vi.mock("@wecom/aibot-node-sdk", async () => await import("./test-sdk-mock.js"));
 
+import { resetMockSdkBehavior, setMockDisconnectErrorMessage } from "./test-sdk-mock.js";
 import { resolveWecomAccount, type PluginConfig } from "./config.js";
 import { clearWecomRuntime, setWecomRuntime } from "./runtime.js";
 import {
@@ -28,6 +29,7 @@ describe("wecom ws gateway", () => {
   afterEach(() => {
     stopWecomWsGatewayForAccount("default");
     clearWecomRuntime();
+    resetMockSdkBehavior();
   });
 
   it("subscribes, heartbeats, and proactively sends after activation", async () => {
@@ -426,6 +428,90 @@ describe("wecom ws gateway", () => {
 
     controller.abort();
     await expect(gatewayPromise).resolves.toBeUndefined();
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+
+  it("suppresses expected shutdown ws errors during abort cleanup", async () => {
+    setMockDisconnectErrorMessage("Invalid WebSocket frame: invalid opcode 3");
+
+    const server = new WebSocketServer({ port: 0 });
+    await once(server, "listening");
+
+    server.on("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const frame = JSON.parse(raw.toString()) as WecomWsFrame;
+        if (!frame.cmd) return;
+        socket.send(
+          JSON.stringify({
+            cmd: frame.cmd,
+            headers: {
+              req_id: frame.headers?.req_id,
+            },
+            errcode: 0,
+          })
+        );
+      });
+    });
+
+    const { port } = server.address() as AddressInfo;
+    const cfg: PluginConfig = {
+      channels: {
+        wecom: {
+          mode: "ws",
+          botId: "bot-1",
+          secret: "secret-1",
+          wsUrl: `ws://127.0.0.1:${port}`,
+          heartbeatIntervalMs: 20,
+          reconnectInitialDelayMs: 10,
+          reconnectMaxDelayMs: 40,
+        },
+      },
+    };
+    const account = resolveWecomAccount({ cfg, accountId: "default" });
+    const statuses: Array<Record<string, unknown>> = [];
+    const errors: string[] = [];
+    const controller = new AbortController();
+
+    const gatewayPromise = startWecomWsGateway({
+      cfg,
+      account,
+      abortSignal: controller.signal,
+      runtime: {
+        log: () => {},
+        error: (message) => {
+          errors.push(message);
+        },
+      },
+      setStatus: (status) => {
+        statuses.push(status);
+      },
+    });
+
+    await waitFor(() => statuses.some((status) => status.connectionState === "ready"));
+
+    controller.abort();
+    await expect(gatewayPromise).resolves.toBeUndefined();
+
+    expect(errors).not.toContain(expect.stringContaining("invalid opcode 3"));
+    expect(
+      statuses.some(
+        (status) =>
+          status.connectionState === "disconnected" &&
+          status.running === false &&
+          typeof status.lastDisconnectAt === "number"
+      )
+    ).toBe(true);
+    expect(
+      statuses.some(
+        (status) => typeof status.lastError === "string" && String(status.lastError).includes("invalid opcode 3")
+      )
+    ).toBe(false);
 
     await new Promise<void>((resolve, reject) => {
       server.close((err) => {

--- a/extensions/wecom/src/ws-gateway.ts
+++ b/extensions/wecom/src/ws-gateway.ts
@@ -39,6 +39,7 @@ type ActiveConnection = {
 const activeConnections = new Map<string, ActiveConnection>();
 const processedMessageIds = new Map<string, number>();
 const PROCESSED_MESSAGE_TTL_MS = 10 * 60 * 1000;
+const WECOM_WS_SHUTDOWN_GRACE_MS = 1_000;
 const activatedTargets = new Map<
   string,
   {
@@ -177,7 +178,16 @@ function summarizeWecomReplyFrame(frame: WecomWsFrame): string {
   return JSON.stringify(summary);
 }
 
-function createSdkLogger(logger: Logger) {
+function isExpectedShutdownWsLog(message: string): boolean {
+  const lowered = message.toLowerCase();
+  return (
+    lowered.includes("invalid websocket frame") ||
+    lowered.includes("invalid opcode") ||
+    lowered.includes("websocket connection closed: code: 1006")
+  );
+}
+
+function createSdkLogger(logger: Logger, opts?: { isShuttingDown?: () => boolean }) {
   return {
     debug(message: string, ...args: unknown[]) {
       logger.debug(formatLogMessage(message, args));
@@ -186,12 +196,27 @@ function createSdkLogger(logger: Logger) {
       logger.info(formatLogMessage(message, args));
     },
     warn(message: string, ...args: unknown[]) {
-      logger.warn(formatLogMessage(message, args));
+      const formatted = formatLogMessage(message, args);
+      if (opts?.isShuttingDown?.() && isExpectedShutdownWsLog(formatted)) {
+        logger.debug(`wecom ws shutdown noise suppressed: ${formatted}`);
+        return;
+      }
+      logger.warn(formatted);
     },
     error(message: string, ...args: unknown[]) {
-      logger.error(formatLogMessage(message, args));
+      const formatted = formatLogMessage(message, args);
+      if (opts?.isShuttingDown?.() && isExpectedShutdownWsLog(formatted)) {
+        logger.debug(`wecom ws shutdown noise suppressed: ${formatted}`);
+        return;
+      }
+      logger.error(formatted);
     },
   };
+}
+
+function isExpectedShutdownWsError(error: Error): boolean {
+  const message = error.message.toLowerCase();
+  return message.includes("invalid websocket frame") || message.includes("invalid opcode");
 }
 
 function requireActiveClient(accountId: string): WSClient {
@@ -298,6 +323,8 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
 
   conn.promise = new Promise<void>((resolve, reject) => {
     let finished = false;
+    let shuttingDown = false;
+    let shutdownTimer: NodeJS.Timeout | null = null;
 
     const client = new WSClient({
       botId: account.botId ?? "",
@@ -306,20 +333,19 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
       heartbeatInterval: account.heartbeatIntervalMs,
       reconnectInterval: account.reconnectInitialDelayMs,
       maxReconnectAttempts: -1,
-      logger: createSdkLogger(logger),
+      logger: createSdkLogger(logger, { isShuttingDown: () => shuttingDown }),
     });
     conn.client = client;
 
-    const finish = (err?: unknown) => {
+    const cleanup = (err?: unknown) => {
       if (finished) return;
       finished = true;
+      if (shutdownTimer) {
+        clearTimeout(shutdownTimer);
+        shutdownTimer = null;
+      }
       abortSignal?.removeEventListener("abort", onAbort);
       client.removeAllListeners();
-      try {
-        client.disconnect();
-      } catch {
-        // ignore
-      }
       clearWecomWsReplyContextsForAccount(account.accountId);
       clearActivatedTargetsForAccount(account.accountId);
       conn.client = null;
@@ -336,9 +362,31 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
       else resolve();
     };
 
+    const beginShutdown = (err?: unknown) => {
+      if (finished) return;
+      if (shuttingDown) {
+        if (err) {
+          cleanup(err);
+        }
+        return;
+      }
+      shuttingDown = true;
+      abortSignal?.removeEventListener("abort", onAbort);
+      shutdownTimer = setTimeout(() => {
+        logger.warn(`wecom ws shutdown timed out for account ${account.accountId}; forcing cleanup`);
+        cleanup(err);
+      }, WECOM_WS_SHUTDOWN_GRACE_MS);
+      shutdownTimer.unref?.();
+      try {
+        client.disconnect();
+      } catch (disconnectErr) {
+        cleanup(err ?? disconnectErr);
+      }
+    };
+
     const onAbort = () => {
       logger.info("abort signal received, stopping wecom ws gateway");
-      finish();
+      beginShutdown();
     };
 
     const handleMessageCallback = (frame: SdkWsFrame) => {
@@ -596,14 +644,21 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
       setStatus?.({
         accountId: account.accountId,
         mode: "ws",
-        running: true,
+        running: !shuttingDown,
         connectionState: "disconnected",
         lastDisconnectAt: Date.now(),
         lastDisconnectReason: reason,
       });
+      if (shuttingDown) {
+        cleanup();
+      }
     });
 
     client.on("error", (error) => {
+      if (shuttingDown && isExpectedShutdownWsError(error)) {
+        logger.debug(`wecom ws shutdown noise suppressed: ${error.message}`);
+        return;
+      }
       logger.error(`wecom ws sdk error: ${error.message}`);
       setStatus?.({
         accountId: account.accountId,
@@ -614,11 +669,11 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
     });
 
     conn.stop = () => {
-      finish();
+      beginShutdown();
     };
 
     if (abortSignal?.aborted) {
-      finish();
+      beginShutdown();
       return;
     }
 
@@ -627,7 +682,7 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
     try {
       client.connect();
     } catch (err) {
-      finish(err);
+      cleanup(err);
     }
   });
 


### PR DESCRIPTION
## Summary
- delay `wecom/ws` cleanup until the client reaches a real disconnected state during abort/stop
- suppress expected shutdown-only `invalid opcode 3` / `code 1006` noise so it does not pollute plugin error status
- add a regression test that simulates SDK disconnect-time error emission

## Why
In local reproduction, steady-state WeCom messaging was healthy, but gateway hot reload / restart could hit this shutdown path:

```text
[wecom] [ERROR] WebSocket error: Invalid WebSocket frame: invalid opcode 3
libc++abi: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
```

This PR only addresses the plugin-side shutdown sequencing and noise classification. It does not claim to fully solve any deeper upstream SDK/native exit bug, but it removes avoidable plugin-side amplification.

Closes #182
Related to #178

## Validation
- `pnpm exec vitest run src/ws-gateway.test.ts`
