### PR TITLE
fix(wecom): reconnect after disconnected_event

### DIFF
--- a/extensions/wecom/src/test-sdk-mock.ts
+++ b/extensions/wecom/src/test-sdk-mock.ts
@@ -56,6 +56,12 @@ export class WSClient extends EventEmitter {
   }
 
   connect(): this {
+    this.clearHeartbeat();
+    if (this.socket) {
+      this.socket.removeAllListeners();
+      this.socket.terminate();
+      this.socket = null;
+    }
     this.socket = new WebSocket(this.wsUrl);
 
     this.socket.on("open", () => {

--- a/extensions/wecom/src/ws-gateway.test.ts
+++ b/extensions/wecom/src/ws-gateway.test.ts
@@ -2,7 +2,7 @@ import { once } from "node:events";
 import type { AddressInfo } from "node:net";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { WebSocketServer } from "ws";
+import { WebSocketServer, type WebSocket } from "ws";
 
 vi.mock("@wecom/aibot-node-sdk", async () => await import("./test-sdk-mock.js"));
 
@@ -130,6 +130,102 @@ describe("wecom ws gateway", () => {
     controller.abort();
     await expect(gatewayPromise).resolves.toBeUndefined();
     expect(statuses.some((status) => status.running === false)).toBe(true);
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+
+  it("forces a reconnect when the server emits disconnected_event", async () => {
+    const server = new WebSocketServer({ port: 0 });
+    await once(server, "listening");
+
+    const received: WecomWsFrame[] = [];
+    let latestSocket: WebSocket | null = null;
+    server.on("connection", (socket) => {
+      latestSocket = socket;
+      socket.on("message", (raw) => {
+        const frame = JSON.parse(raw.toString()) as WecomWsFrame;
+        received.push(frame);
+        if (frame.cmd === "aibot_msg_callback" || frame.cmd === "aibot_event_callback") {
+          return;
+        }
+        socket.send(
+          JSON.stringify({
+            cmd: frame.cmd,
+            headers: {
+              req_id: frame.headers?.req_id,
+            },
+            errcode: 0,
+          })
+        );
+      });
+    });
+
+    const { port } = server.address() as AddressInfo;
+    const cfg: PluginConfig = {
+      channels: {
+        wecom: {
+          mode: "ws",
+          botId: "bot-1",
+          secret: "secret-1",
+          wsUrl: `ws://127.0.0.1:${port}`,
+          heartbeatIntervalMs: 20,
+          reconnectInitialDelayMs: 10,
+          reconnectMaxDelayMs: 40,
+        },
+      },
+    };
+    const account = resolveWecomAccount({ cfg, accountId: "default" });
+    const statuses: Array<Record<string, unknown>> = [];
+    const controller = new AbortController();
+
+    const gatewayPromise = startWecomWsGateway({
+      cfg,
+      account,
+      abortSignal: controller.signal,
+      runtime: {
+        log: () => {},
+        error: () => {},
+      },
+      setStatus: (status) => {
+        statuses.push(status);
+      },
+    });
+
+    await waitFor(
+      () =>
+        received.filter((frame) => frame.cmd === "aibot_subscribe").length >= 1 &&
+        statuses.some((status) => status.connectionState === "ready")
+    );
+
+    latestSocket?.send(
+      JSON.stringify({
+        cmd: "aibot_event_callback",
+        headers: {
+          req_id: "req-disconnected-1",
+        },
+        body: {
+          msgid: "event-disconnected-1",
+          chattype: "single",
+          from: { userid: "user-1" },
+          msgtype: "event",
+          event: {
+            eventtype: "disconnected_event",
+          },
+        },
+      })
+    );
+
+    await waitFor(() => received.filter((frame) => frame.cmd === "aibot_subscribe").length >= 2);
+    expect(statuses.some((status) => status.lastDisconnectReason === "disconnected_event")).toBe(true);
+    expect(statuses.filter((status) => status.connectionState === "ready").length).toBeGreaterThanOrEqual(2);
+
+    controller.abort();
+    await expect(gatewayPromise).resolves.toBeUndefined();
 
     await new Promise<void>((resolve, reject) => {
       server.close((err) => {

--- a/extensions/wecom/src/ws-gateway.ts
+++ b/extensions/wecom/src/ws-gateway.ts
@@ -40,6 +40,7 @@ const activeConnections = new Map<string, ActiveConnection>();
 const processedMessageIds = new Map<string, number>();
 const PROCESSED_MESSAGE_TTL_MS = 10 * 60 * 1000;
 const WECOM_WS_SHUTDOWN_GRACE_MS = 1_000;
+const WECOM_WS_EVENT_RECONNECT_COOLDOWN_MS = 5_000;
 const activatedTargets = new Map<
   string,
   {
@@ -325,6 +326,8 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
     let finished = false;
     let shuttingDown = false;
     let shutdownTimer: NodeJS.Timeout | null = null;
+    let eventReconnectTimer: NodeJS.Timeout | null = null;
+    let lastEventReconnectAt = 0;
 
     const client = new WSClient({
       botId: account.botId ?? "",
@@ -343,6 +346,10 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
       if (shutdownTimer) {
         clearTimeout(shutdownTimer);
         shutdownTimer = null;
+      }
+      if (eventReconnectTimer) {
+        clearTimeout(eventReconnectTimer);
+        eventReconnectTimer = null;
       }
       abortSignal?.removeEventListener("abort", onAbort);
       client.removeAllListeners();
@@ -387,6 +394,49 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
     const onAbort = () => {
       logger.info("abort signal received, stopping wecom ws gateway");
       beginShutdown();
+    };
+
+    const scheduleEventReconnect = (reason: string) => {
+      if (finished || shuttingDown) return;
+      const now = Date.now();
+      if (eventReconnectTimer) {
+        logger.debug(`wecom ws reconnect already scheduled for account ${account.accountId}`);
+        return;
+      }
+      if (now - lastEventReconnectAt < WECOM_WS_EVENT_RECONNECT_COOLDOWN_MS) {
+        logger.warn(
+          `wecom ws reconnect for account ${account.accountId} suppressed by cooldown (${reason})`
+        );
+        return;
+      }
+      lastEventReconnectAt = now;
+      setStatus?.({
+        accountId: account.accountId,
+        mode: "ws",
+        running: true,
+        connectionState: "reconnecting",
+        lastDisconnectAt: now,
+        lastDisconnectReason: reason,
+      });
+      eventReconnectTimer = setTimeout(() => {
+        eventReconnectTimer = null;
+        if (finished || shuttingDown) return;
+        logger.warn(`forcing wecom ws reconnect for account ${account.accountId} (${reason})`);
+        try {
+          client.connect();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.error(`wecom ws forced reconnect failed: ${message}`);
+          setStatus?.({
+            accountId: account.accountId,
+            mode: "ws",
+            connectionState: "disconnected",
+            lastErrorAt: Date.now(),
+            lastError: message,
+          });
+        }
+      }, 0);
+      eventReconnectTimer.unref?.();
     };
 
     const handleMessageCallback = (frame: SdkWsFrame) => {
@@ -513,6 +563,7 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
           lastDisconnectAt: Date.now(),
           lastDisconnectReason: "disconnected_event",
         });
+        scheduleEventReconnect("disconnected_event");
         return;
       }
 


### PR DESCRIPTION
## Summary
- force a WeCom WS reconnect when the server emits `disconnected_event`
- add a cooldown so repeated events do not thrash the connection
- add a regression test proving one `disconnected_event` triggers a fresh `aibot_subscribe`

## Verification
- `pnpm -C extensions/wecom exec vitest run src/ws-gateway.test.ts`

Closes #184
