### PR TITLE
fix(wecom): use native thinking stream placeholder

### DIFF
--- a/extensions/wecom/src/bot.ts
+++ b/extensions/wecom/src/bot.ts
@@ -42,6 +42,7 @@ export type WecomDispatchHooks = {
   onRouteContext?: (context: { sessionKey?: string; runId?: string }) => void;
   onChunk: (text: string) => void | Promise<void>;
   onRichChunk?: (chunk: WecomWsReplyChunk) => void | Promise<void>;
+  onSkip?: (info: { kind: string; reason: string }) => void;
   onError?: (err: unknown) => void;
 };
 
@@ -650,6 +651,9 @@ export async function dispatchWecomMessage(params: {
           });
           if (!normalized.trim()) return;
           await hooks.onChunk(normalized);
+        },
+        onSkip: (_payload: unknown, info: { kind: string; reason: string }) => {
+          hooks.onSkip?.(info);
         },
         onError: (err: unknown, info: { kind: string }) => {
           hooks.onError?.(err);

--- a/extensions/wecom/src/runtime.ts
+++ b/extensions/wecom/src/runtime.ts
@@ -26,6 +26,7 @@ export interface PluginRuntime {
         cfg: unknown;
         dispatcherOptions: {
           deliver: (payload: { text?: string; mediaUrl?: string; mediaUrls?: string[] }) => Promise<void>;
+          onSkip?: (payload: unknown, info: { kind: string; reason: string }) => void;
           onError?: (err: unknown, info: { kind: string }) => void;
         };
       }) => Promise<void>;

--- a/extensions/wecom/src/ws-gateway.test.ts
+++ b/extensions/wecom/src/ws-gateway.test.ts
@@ -462,6 +462,131 @@ describe("wecom ws gateway", () => {
     });
   });
 
+  it("finishes a skipped reply without turning the hidden placeholder into a visible message", async () => {
+    const server = new WebSocketServer({ port: 0 });
+    await once(server, "listening");
+
+    const received: WecomWsFrame[] = [];
+    server.on("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const frame = JSON.parse(raw.toString()) as WecomWsFrame;
+        received.push(frame);
+        if (frame.cmd === "aibot_msg_callback" || frame.cmd === "aibot_event_callback") {
+          return;
+        }
+        socket.send(
+          JSON.stringify({
+            cmd: frame.cmd,
+            headers: {
+              req_id: frame.headers?.req_id,
+            },
+            errcode: 0,
+          })
+        );
+      });
+    });
+
+    const { port } = server.address() as AddressInfo;
+    const cfg: PluginConfig = {
+      channels: {
+        wecom: {
+          mode: "ws",
+          dmPolicy: "open",
+          botId: "bot-1",
+          secret: "secret-1",
+          wsUrl: `ws://127.0.0.1:${port}`,
+          heartbeatIntervalMs: 20,
+          reconnectInitialDelayMs: 10,
+          reconnectMaxDelayMs: 40,
+        },
+      },
+    };
+    const account = resolveWecomAccount({ cfg, accountId: "default" });
+    setWecomRuntime({
+      channel: {
+        routing: {
+          resolveAgentRoute: () => ({
+            sessionKey: "session-1",
+            accountId: account.accountId,
+          }),
+        },
+        reply: {
+          dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
+            await dispatcherOptions.onSkip?.({}, { kind: "final", reason: "silent" });
+          },
+        },
+      },
+    });
+
+    const controller = new AbortController();
+    const gatewayPromise = startWecomWsGateway({
+      cfg,
+      account,
+      abortSignal: controller.signal,
+      runtime: {
+        log: () => {},
+        error: () => {},
+      },
+    });
+
+    await waitFor(() => received.some((frame) => frame.cmd === "aibot_subscribe"));
+
+    const client = [...server.clients][0];
+    client?.send(
+      JSON.stringify({
+        cmd: "aibot_msg_callback",
+        headers: {
+          req_id: "req-skip-1",
+        },
+        body: {
+          msgid: "msg-skip-1",
+          chattype: "single",
+          from: { userid: "user-1" },
+          msgtype: "text",
+          text: { content: "hello" },
+        },
+      })
+    );
+
+    await waitFor(
+      () => received.filter((frame) => frame.cmd === "aibot_respond_msg" && frame.body).length >= 2,
+      4_000
+    );
+
+    const replies = received.filter((frame) => frame.cmd === "aibot_respond_msg");
+    expect(replies).toHaveLength(2);
+    expect(replies[0]).toMatchObject({
+      headers: { req_id: "req-skip-1" },
+      body: {
+        msgtype: "stream",
+        stream: {
+          finish: false,
+          content: WECOM_WS_THINKING_MESSAGE,
+        },
+      },
+    });
+    expect(replies[1]).toMatchObject({
+      headers: { req_id: "req-skip-1" },
+      body: {
+        msgtype: "stream",
+        stream: {
+          finish: true,
+        },
+      },
+    });
+    expect(((replies[1].body as { stream?: { content?: string } }).stream?.content)).toBeUndefined();
+
+    controller.abort();
+    await expect(gatewayPromise).resolves.toBeUndefined();
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+
   it("fetches doc MCP config after ws authentication and saves it under the OpenClaw state dir", async () => {
     const tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "wecom-mcp-state-"));
     const previousOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;

--- a/extensions/wecom/src/ws-gateway.ts
+++ b/extensions/wecom/src/ws-gateway.ts
@@ -14,6 +14,7 @@ import {
   appendWecomWsActiveStreamReply,
   bindWecomWsRouteContext,
   clearWecomWsReplyContextsForAccount,
+  markWecomWsMessageContextSkipped,
   registerWecomWsEventContext,
   registerWecomWsMessageContext,
   scheduleWecomWsMessageContextFinish,
@@ -468,6 +469,13 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
               reqId: callback.reqId,
               sessionKey: context.sessionKey,
               runId: context.runId,
+            });
+          },
+          onSkip: (info) => {
+            markWecomWsMessageContextSkipped({
+              accountId: account.accountId,
+              reqId: callback.reqId,
+              reason: info.reason,
             });
           },
           onChunk: async (text) => {

--- a/extensions/wecom/src/ws-reply-context.test.ts
+++ b/extensions/wecom/src/ws-reply-context.test.ts
@@ -9,6 +9,7 @@ import {
   clearWecomWsReplyContextsForAccount,
   consumeWecomWsPendingAutoImagePaths,
   finishWecomWsMessageContext,
+  markWecomWsMessageContextSkipped,
   registerWecomWsEventContext,
   registerWecomWsMessageContext,
   registerWecomWsPendingAutoImagePaths,
@@ -297,6 +298,58 @@ describe("wecom ws reply context", () => {
         },
       },
     });
+  });
+
+  it("closes the thinking stream without a visible finish message when the reply was skipped", async () => {
+    const sent: Array<{ body?: { stream?: { id?: string; finish?: boolean; content?: string } } }> = [];
+    registerWecomWsMessageContext({
+      accountId: "acc-1",
+      reqId: "req-skip-only",
+      to: "user:alice",
+      send: async (frame) => {
+        sent.push(frame as { body?: { stream?: { id?: string; finish?: boolean; content?: string } } });
+      },
+      streamId: "stream-skip-only",
+    });
+
+    await expect(
+      sendWecomWsMessagePlaceholder({
+        accountId: "acc-1",
+        reqId: "req-skip-only",
+        content: WECOM_WS_THINKING_MESSAGE,
+      })
+    ).resolves.toBe(true);
+
+    markWecomWsMessageContextSkipped({
+      accountId: "acc-1",
+      reqId: "req-skip-only",
+      reason: "silent",
+    });
+
+    await finishWecomWsMessageContext({
+      accountId: "acc-1",
+      reqId: "req-skip-only",
+    });
+
+    expect(sent).toHaveLength(2);
+    expect(sent[0]).toMatchObject({
+      body: {
+        stream: {
+          id: "stream-skip-only",
+          finish: false,
+          content: WECOM_WS_THINKING_MESSAGE,
+        },
+      },
+    });
+    expect(sent[1]).toMatchObject({
+      body: {
+        stream: {
+          id: "stream-skip-only",
+          finish: true,
+        },
+      },
+    });
+    expect(sent[1].body?.stream?.content).toBeUndefined();
   });
 
   it("stores image msg items and emits them only on the final frame", async () => {

--- a/extensions/wecom/src/ws-reply-context.ts
+++ b/extensions/wecom/src/ws-reply-context.ts
@@ -25,6 +25,7 @@ type WsMessageContext = {
   sessionKey?: string;
   runId?: string;
   placeholderContent: string;
+  suppressVisibleFallback: boolean;
   started: boolean;
   finished: boolean;
   queue: Promise<void>;
@@ -47,7 +48,6 @@ const EVENT_CONTEXT_TTL_MS = 10 * 1000;
 const STREAM_FINISH_GRACE_MS = 2_500;
 export const WECOM_WS_THINKING_MESSAGE = "<think></think>";
 export const WECOM_WS_FINISH_FALLBACK_MESSAGE = "✅ 处理完成。";
-export const WECOM_WS_MEDIA_FINISH_MESSAGE = "📎 文件已发送，请查收。";
 
 const messageContexts = new Map<string, WsMessageContext>();
 const eventContexts = new Map<string, WsEventContext>();
@@ -270,6 +270,7 @@ export function registerWecomWsMessageContext(params: {
     createdAt: now(),
     updatedAt: now(),
     placeholderContent: "",
+    suppressVisibleFallback: false,
     started: false,
     finished: false,
     queue: Promise.resolve(),
@@ -351,6 +352,21 @@ export function bindWecomWsRouteContext(params: {
     context.runId = runId;
     messageByRunId.set(routeKey(context.accountId, runId), key);
   }
+  context.updatedAt = now();
+}
+
+export function markWecomWsMessageContextSkipped(params: {
+  accountId: string;
+  reqId: string;
+  reason?: string;
+}): void {
+  pruneMessageContexts();
+  const key = messageKey(params.accountId.trim(), params.reqId.trim());
+  const context = messageContexts.get(key);
+  if (!context || context.finished) return;
+  const reason = String(params.reason ?? "").trim();
+  if (!reason) return;
+  context.suppressVisibleFallback = true;
   context.updatedAt = now();
 }
 
@@ -517,13 +533,12 @@ export async function finishWecomWsMessageContext(params: {
         ? `${context.content}\n\n${errorMessage}`
         : errorMessage
       : context.content;
-    const fallbackContent = !finalContent
-      ? context.msgItems.length > 0
-        ? WECOM_WS_MEDIA_FINISH_MESSAGE
-        : context.placeholderContent === WECOM_WS_THINKING_MESSAGE
-          ? WECOM_WS_FINISH_FALLBACK_MESSAGE
-          : undefined
-      : undefined;
+    const fallbackContent =
+      !finalContent &&
+      !context.suppressVisibleFallback &&
+      context.placeholderContent === WECOM_WS_THINKING_MESSAGE
+        ? WECOM_WS_FINISH_FALLBACK_MESSAGE
+        : undefined;
     const finishContent = finalContent || fallbackContent;
     const sendFinish = context.started || Boolean(finishContent) || context.msgItems.length > 0;
     if (sendFinish) {


### PR DESCRIPTION
## Summary

- replace the static `⏳` WS placeholder with WeCom's native `<think></think>` stream token
- finish native thinking streams with a visible fallback when no real text arrives
- add regression coverage for placeholder overwrite and empty-finish fallback

Closes #186.

## Testing

- `pnpm -C extensions/wecom exec vitest run src/ws-reply-context.test.ts src/ws-gateway.test.ts`
