### PR TITLE
feat(wecom): add configurable reply footer metadata

### DIFF
--- a/doc/guides/wecom/configuration.md
+++ b/doc/guides/wecom/configuration.md
@@ -101,6 +101,8 @@ openclaw config set channels.wecom.enabled true
 openclaw config set channels.wecom.mode ws
 openclaw config set channels.wecom.botId your-bot-id
 openclaw config set channels.wecom.secret your-secret
+openclaw config set channels.wecom.footer.elapsed true
+openclaw config set channels.wecom.footer.status true
 ```
 
 也可以直接编辑配置：
@@ -112,7 +114,11 @@ openclaw config set channels.wecom.secret your-secret
       "enabled": true,
       "mode": "ws",
       "botId": "your-bot-id",
-      "secret": "your-secret"
+      "secret": "your-secret",
+      "footer": {
+        "elapsed": true,
+        "status": true
+      }
     }
   }
 }
@@ -124,6 +130,10 @@ openclaw config set channels.wecom.secret your-secret
 - `heartbeatIntervalMs`: 心跳间隔，默认 30000
 - `reconnectInitialDelayMs`: 首次重连延迟，默认 1000
 - `reconnectMaxDelayMs`: 最大重连延迟，默认 30000
+- `footer.elapsed`: 在最终回复尾部显示耗时
+- `footer.status`: 在最终回复尾部显示状态（已完成 / 出错 / 已停止）
+
+当前 `footer.*` 按“文本尾注”渲染，适用于 `ws` 和 `webhook`；这不是飞书 CardKit 那种独立卡片 footer 槽位。
 
 ## 四、启动并验证
 
@@ -138,4 +148,3 @@ openclaw gateway --port 18789 --verbose
 ```bash
 openclaw daemon start
 ```
-

--- a/extensions/wecom/openclaw.plugin.json
+++ b/extensions/wecom/openclaw.plugin.json
@@ -30,6 +30,14 @@
       "groupPolicy": { "type": "string", "enum": ["open", "allowlist", "disabled"] },
       "groupAllowFrom": { "type": "array", "items": { "type": "string" } },
       "requireMention": { "type": "boolean" },
+      "footer": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "status": { "type": "boolean" },
+          "elapsed": { "type": "boolean" }
+        }
+      },
       "defaultAccount": { "type": "string" },
       "accounts": {
         "type": "object",
@@ -57,7 +65,15 @@
             "allowFrom": { "type": "array", "items": { "type": "string" } },
             "groupPolicy": { "type": "string", "enum": ["open", "allowlist", "disabled"] },
             "groupAllowFrom": { "type": "array", "items": { "type": "string" } },
-            "requireMention": { "type": "boolean" }
+            "requireMention": { "type": "boolean" },
+            "footer": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "status": { "type": "boolean" },
+                "elapsed": { "type": "boolean" }
+              }
+            }
           }
         }
       }

--- a/extensions/wecom/src/config.test.ts
+++ b/extensions/wecom/src/config.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_WECOM_WS_RECONNECT_INITIAL_MS,
   DEFAULT_WECOM_WS_RECONNECT_MAX_MS,
   DEFAULT_WECOM_WS_URL,
+  parseWecomConfig,
   resolveWecomAccount,
 } from "./config.js";
 
@@ -85,5 +86,71 @@ describe("resolveWecomAccount", () => {
     });
 
     expect(account.wsImageReplyMode).toBe("markdown-url");
+  });
+
+  it("merges footer config from top-level defaults and per-account overrides", () => {
+    const account = resolveWecomAccount({
+      cfg: {
+        channels: {
+          wecom: {
+            mode: "ws",
+            botId: "bot-123",
+            secret: "secret-xyz",
+            footer: {
+              status: true,
+              elapsed: false,
+            },
+            accounts: {
+              zhugeliang: {
+                botId: "bot-456",
+                secret: "secret-456",
+                footer: {
+                  elapsed: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      accountId: "zhugeliang",
+    });
+
+    expect(account.config.footer).toEqual({
+      status: true,
+      elapsed: true,
+    });
+  });
+
+  it("parses footer flags from schema", () => {
+    const parsed = parseWecomConfig({
+      mode: "ws",
+      botId: "bot-123",
+      secret: "secret-xyz",
+      footer: {
+        status: true,
+        elapsed: true,
+      },
+      accounts: {
+        main: {
+          footer: {
+            elapsed: false,
+          },
+        },
+      },
+    });
+
+    expect(parsed).toMatchObject({
+      footer: {
+        status: true,
+        elapsed: true,
+      },
+      accounts: {
+        main: {
+          footer: {
+            elapsed: false,
+          },
+        },
+      },
+    });
   });
 });

--- a/extensions/wecom/src/config.ts
+++ b/extensions/wecom/src/config.ts
@@ -6,6 +6,7 @@ import type {
   WecomAccountConfig,
   WecomConfig,
   WecomDmPolicy,
+  WecomFooterConfig,
   WecomGroupPolicy,
   WecomTransportMode,
   WecomWsImageReplyMode,
@@ -40,6 +41,12 @@ const WecomAccountSchema = z.object({
   groupPolicy: z.enum(["open", "allowlist", "disabled"]).optional(),
   groupAllowFrom: z.array(z.string()).optional(),
   requireMention: z.boolean().optional(),
+  footer: z
+    .object({
+      status: z.boolean().optional(),
+      elapsed: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 export const WecomConfigSchema = WecomAccountSchema.extend({
@@ -75,6 +82,14 @@ export const WecomConfigJsonSchema = {
       groupPolicy: { type: "string", enum: ["open", "allowlist", "disabled"] },
       groupAllowFrom: { type: "array", items: { type: "string" } },
       requireMention: { type: "boolean" },
+      footer: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          status: { type: "boolean" },
+          elapsed: { type: "boolean" },
+        },
+      },
       defaultAccount: { type: "string" },
       accounts: {
         type: "object",
@@ -102,7 +117,15 @@ export const WecomConfigJsonSchema = {
             allowFrom: { type: "array", items: { type: "string" } },
             groupPolicy: { type: "string", enum: ["open", "allowlist", "disabled"] },
             groupAllowFrom: { type: "array", items: { type: "string" } },
-            requireMention: { type: "boolean" }
+            requireMention: { type: "boolean" },
+            footer: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                status: { type: "boolean" },
+                elapsed: { type: "boolean" },
+              },
+            }
           }
         }
       }
@@ -168,7 +191,13 @@ function mergeWecomAccountConfig(cfg: PluginConfig, accountId: string): WecomAcc
   const base = (cfg.channels?.wecom ?? {}) as WecomConfig;
   const { accounts: _ignored, defaultAccount: _ignored2, ...baseConfig } = base;
   const account = resolveAccountConfig(cfg, accountId) ?? {};
-  return { ...baseConfig, ...account };
+  const footer: WecomFooterConfig | undefined =
+    baseConfig.footer || account.footer ? { ...(baseConfig.footer ?? {}), ...(account.footer ?? {}) } : undefined;
+  return {
+    ...baseConfig,
+    ...account,
+    footer,
+  };
 }
 
 export function resolveWecomAccount(params: { cfg: PluginConfig; accountId?: string | null }): ResolvedWecomAccount {

--- a/extensions/wecom/src/footer.ts
+++ b/extensions/wecom/src/footer.ts
@@ -1,0 +1,55 @@
+import type { WecomFooterConfig } from "./types.js";
+
+export type ResolvedWecomFooterConfig = {
+  status: boolean;
+  elapsed: boolean;
+};
+
+export const DEFAULT_WECOM_FOOTER_CONFIG: ResolvedWecomFooterConfig = {
+  status: false,
+  elapsed: false,
+};
+
+export function resolveWecomFooterConfig(config?: WecomFooterConfig): ResolvedWecomFooterConfig {
+  if (!config) return { ...DEFAULT_WECOM_FOOTER_CONFIG };
+  return {
+    status: config.status ?? DEFAULT_WECOM_FOOTER_CONFIG.status,
+    elapsed: config.elapsed ?? DEFAULT_WECOM_FOOTER_CONFIG.elapsed,
+  };
+}
+
+export function formatWecomElapsed(ms: number): string {
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+}
+
+export function buildWecomFooterText(params: {
+  footer?: WecomFooterConfig;
+  createdAt: number;
+  finishedAt?: number;
+  isError?: boolean;
+  isAborted?: boolean;
+}): string {
+  const footer = resolveWecomFooterConfig(params.footer);
+  const parts: string[] = [];
+  if (footer.status) {
+    if (params.isAborted) parts.push("已停止");
+    else if (params.isError) parts.push("出错");
+    else parts.push("已完成");
+  }
+  if (footer.elapsed) {
+    const finishedAt = params.finishedAt ?? Date.now();
+    const elapsedMs = Math.max(0, finishedAt - params.createdAt);
+    parts.push(`耗时 ${formatWecomElapsed(elapsedMs)}`);
+  }
+  return parts.join(" · ");
+}
+
+export function appendWecomFooterText(content: string | undefined, footerText: string): string | undefined {
+  const trimmedFooter = footerText.trim();
+  if (!trimmedFooter) return content;
+  const trimmedContent = String(content ?? "").trim();
+  if (!trimmedContent) return undefined;
+  return `${trimmedContent}\n\n——\n${trimmedFooter}`;
+}

--- a/extensions/wecom/src/monitor.ts
+++ b/extensions/wecom/src/monitor.ts
@@ -6,6 +6,7 @@ import { createLogger, type Logger } from "@openclaw-china/shared";
 import type { ResolvedWecomAccount, WecomInboundMessage } from "./types.js";
 import type { PluginConfig } from "./config.js";
 import { decryptWecomEncrypted, encryptWecomPlaintext, verifyWecomSignature, computeWecomMsgSignature } from "./crypto.js";
+import { appendWecomFooterText, buildWecomFooterText, type ResolvedWecomFooterConfig, resolveWecomFooterConfig } from "./footer.js";
 import { dispatchWecomMessage } from "./bot.js";
 import { tryGetWecomRuntime } from "./runtime.js";
 import { handleTempMediaRequest, rememberAccountPublicBaseUrl } from "./outbound-reply.js";
@@ -33,6 +34,7 @@ type StreamState = {
   finished: boolean;
   error?: string;
   content: string;
+  footer: ResolvedWecomFooterConfig;
 };
 
 type StreamRouteBinding = {
@@ -412,7 +414,20 @@ function buildStreamPlaceholderReply(streamId: string): { msgtype: "stream"; str
 }
 
 function buildStreamReplyFromState(state: StreamState): { msgtype: "stream"; stream: { id: string; finish: boolean; content?: string } } {
-  const content = truncateUtf8Bytes(state.content, STREAM_MAX_BYTES);
+  const content = truncateUtf8Bytes(
+    appendWecomFooterText(
+      state.content,
+      state.finished
+        ? buildWecomFooterText({
+            footer: state.footer,
+            createdAt: state.createdAt,
+            finishedAt: state.updatedAt,
+            isError: Boolean(state.error),
+          })
+        : ""
+    ) ?? "",
+    STREAM_MAX_BYTES
+  );
   const stream: { id: string; finish: boolean; content?: string } = {
     id: state.streamId,
     finish: state.finished,
@@ -898,6 +913,7 @@ export async function handleWecomWebhookRequest(req: IncomingMessage, res: Serve
           started: true,
           finished: true,
           content: "",
+          footer: resolveWecomFooterConfig(),
         });
     const encReply = buildEncryptedJsonReply({
       account: target.account,
@@ -990,6 +1006,7 @@ export async function handleWecomWebhookRequest(req: IncomingMessage, res: Serve
     started: false,
     finished: false,
     content: "",
+    footer: resolveWecomFooterConfig(target.account.config.footer),
   });
 
   const core = tryGetWecomRuntime();

--- a/extensions/wecom/src/monitor.webhook.test.ts
+++ b/extensions/wecom/src/monitor.webhook.test.ts
@@ -87,6 +87,7 @@ function createWebhookAccount(path: string): ResolvedWecomAccount {
 describe("wecom webhook transport regressions", () => {
   afterEach(() => {
     clearOutboundReplyState();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -230,6 +231,131 @@ describe("wecom webhook transport regressions", () => {
       expect(streamedReply.msgtype).toBe("stream");
       expect(streamedReply.stream?.content).toContain("hello from reply pipeline");
       expect(streamedReply.stream?.finish).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("appends completion footer metadata to finished webhook streams when enabled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T10:00:00.000Z"));
+
+    const account = {
+      ...createWebhookAccount("/hook-footer"),
+      config: {
+        mode: "webhook",
+        webhookPath: "/hook-footer",
+        token,
+        encodingAESKey,
+        footer: {
+          status: true,
+          elapsed: true,
+        },
+      },
+    };
+    const unregister = registerWecomWebhookTarget({
+      account,
+      config: {} as PluginConfig,
+      runtime: {},
+      path: "/hook-footer",
+    });
+
+    try {
+      const timestamp = "1700000100";
+      const nonce = "nonce-footer-1";
+      const plain = JSON.stringify({
+        msgid: "msg-stream-footer-1",
+        aibotid: "bot-1",
+        chattype: "single",
+        from: { userid: "user-stream-footer-1" },
+        msgtype: "text",
+        text: { content: "hello" },
+      });
+      const encrypt = encryptWecomPlaintext({
+        encodingAESKey,
+        plaintext: plain,
+      });
+      const msgSignature = computeWecomMsgSignature({
+        token,
+        timestamp,
+        nonce,
+        encrypt,
+      });
+
+      const req = createMockRequest({
+        method: "POST",
+        url: `/hook-footer?msg_signature=${encodeURIComponent(msgSignature)}&timestamp=${encodeURIComponent(timestamp)}&nonce=${encodeURIComponent(nonce)}`,
+        body: { encrypt },
+      });
+      const res = createMockResponse();
+
+      const handledPromise = handleWecomWebhookRequest(req, res);
+      await vi.advanceTimersByTimeAsync(850);
+      const handled = await handledPromise;
+      expect(handled).toBe(true);
+
+      const initialReply = JSON.parse(
+        decryptWecomEncrypted({
+          encodingAESKey,
+          encrypt: String((JSON.parse(res._getData()) as { encrypt: string }).encrypt),
+        })
+      ) as {
+        msgtype: string;
+        stream?: { id?: string; content?: string; finish?: boolean };
+      };
+      expect(initialReply.stream?.id).toBeTruthy();
+      expect(initialReply.stream?.finish).toBe(false);
+
+      expect(
+        appendWecomActiveStreamChunk({
+          accountId: account.accountId,
+          to: "user:user-stream-footer-1",
+          chunk: "hello from reply pipeline",
+        })
+      ).toBe(true);
+
+      vi.setSystemTime(new Date("2026-03-17T10:00:03.200Z"));
+      await vi.advanceTimersByTimeAsync(2_600);
+
+      const streamQueryPlain = JSON.stringify({
+        msgtype: "stream",
+        stream: {
+          id: initialReply.stream?.id,
+        },
+      });
+      const streamQueryEncrypt = encryptWecomPlaintext({
+        encodingAESKey,
+        plaintext: streamQueryPlain,
+      });
+      const streamQuerySignature = computeWecomMsgSignature({
+        token,
+        timestamp: "1700000101",
+        nonce: "nonce-footer-2",
+        encrypt: streamQueryEncrypt,
+      });
+      const streamReq = createMockRequest({
+        method: "POST",
+        url: `/hook-footer?msg_signature=${encodeURIComponent(streamQuerySignature)}&timestamp=1700000101&nonce=nonce-footer-2`,
+        body: { encrypt: streamQueryEncrypt },
+      });
+      const streamRes = createMockResponse();
+
+      const streamHandled = await handleWecomWebhookRequest(streamReq, streamRes);
+      expect(streamHandled).toBe(true);
+      expect(streamRes._getStatusCode()).toBe(200);
+
+      const streamedReply = JSON.parse(
+        decryptWecomEncrypted({
+          encodingAESKey,
+          encrypt: String((JSON.parse(streamRes._getData()) as { encrypt: string }).encrypt),
+        })
+      ) as {
+        msgtype: string;
+        stream?: { content?: string; finish?: boolean };
+      };
+      expect(streamedReply.msgtype).toBe("stream");
+      expect(streamedReply.stream?.finish).toBe(true);
+      expect(streamedReply.stream?.content).toBe("hello from reply pipeline\n\n——\n已完成 · 耗时 5.7s");
     } finally {
       unregister();
     }

--- a/extensions/wecom/src/types.ts
+++ b/extensions/wecom/src/types.ts
@@ -2,6 +2,10 @@ export type WecomDmPolicy = "open" | "pairing" | "allowlist" | "disabled";
 export type WecomGroupPolicy = "open" | "allowlist" | "disabled";
 export type WecomTransportMode = "webhook" | "ws";
 export type WecomWsImageReplyMode = "native" | "markdown-url";
+export type WecomFooterConfig = {
+  status?: boolean;
+  elapsed?: boolean;
+};
 
 export type WecomAccountConfig = {
   name?: string;
@@ -29,6 +33,7 @@ export type WecomAccountConfig = {
   groupPolicy?: WecomGroupPolicy;
   groupAllowFrom?: string[];
   requireMention?: boolean;
+  footer?: WecomFooterConfig;
 };
 
 export type WecomConfig = WecomAccountConfig & {

--- a/extensions/wecom/src/ws-gateway.ts
+++ b/extensions/wecom/src/ws-gateway.ts
@@ -426,6 +426,7 @@ export async function startWecomWsGateway(opts: StartWecomWsGatewayOptions): Pro
         accountId: account.accountId,
         reqId: callback.reqId,
         to: callback.target,
+        footer: account.config.footer,
         send: async (replyFrame) => {
           await sendSdkReplyFrame({
             client,

--- a/extensions/wecom/src/ws-reply-context.test.ts
+++ b/extensions/wecom/src/ws-reply-context.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   appendWecomWsActiveStreamChunk,
@@ -18,6 +18,7 @@ import {
 describe("wecom ws reply context", () => {
   afterEach(() => {
     clearWecomWsReplyContextsForAccount("acc-1");
+    vi.restoreAllMocks();
   });
 
   it("separates multiple OpenClaw reply payloads with blank lines and repeats the final content on finish", async () => {
@@ -183,6 +184,91 @@ describe("wecom ws reply context", () => {
           id: "stream-2",
           finish: true,
           content: "partial answer\n\nError: upstream failed",
+        },
+      },
+    });
+  });
+
+  it("appends completion status and elapsed footer on finish when enabled", async () => {
+    const sent: unknown[] = [];
+    let currentTime = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => currentTime);
+    registerWecomWsMessageContext({
+      accountId: "acc-1",
+      reqId: "req-footer",
+      to: "user:alice",
+      footer: {
+        status: true,
+        elapsed: true,
+      },
+      send: async (frame) => {
+        sent.push(frame);
+      },
+      streamId: "stream-footer",
+    });
+
+    currentTime = 1_800;
+    await appendWecomWsActiveStreamChunk({
+      accountId: "acc-1",
+      to: "user:alice",
+      chunk: "final answer",
+    });
+    currentTime = 4_200;
+    await finishWecomWsMessageContext({
+      accountId: "acc-1",
+      reqId: "req-footer",
+    });
+
+    expect(sent).toHaveLength(2);
+    expect(sent[1]).toMatchObject({
+      body: {
+        stream: {
+          id: "stream-footer",
+          finish: true,
+          content: "final answer\n\n——\n已完成 · 耗时 3.2s",
+        },
+      },
+    });
+  });
+
+  it("appends error status footer on failed finish when enabled", async () => {
+    const sent: unknown[] = [];
+    let currentTime = 2_000;
+    vi.spyOn(Date, "now").mockImplementation(() => currentTime);
+    registerWecomWsMessageContext({
+      accountId: "acc-1",
+      reqId: "req-footer-error",
+      to: "user:alice",
+      footer: {
+        status: true,
+        elapsed: true,
+      },
+      send: async (frame) => {
+        sent.push(frame);
+      },
+      streamId: "stream-footer-error",
+    });
+
+    currentTime = 2_500;
+    await appendWecomWsActiveStreamChunk({
+      accountId: "acc-1",
+      to: "user:alice",
+      chunk: "partial answer",
+    });
+    currentTime = 5_700;
+    await finishWecomWsMessageContext({
+      accountId: "acc-1",
+      reqId: "req-footer-error",
+      error: new Error("upstream failed"),
+    });
+
+    expect(sent).toHaveLength(2);
+    expect(sent[1]).toMatchObject({
+      body: {
+        stream: {
+          id: "stream-footer-error",
+          finish: true,
+          content: "partial answer\n\nError: upstream failed\n\n——\n出错 · 耗时 3.7s",
         },
       },
     });

--- a/extensions/wecom/src/ws-reply-context.ts
+++ b/extensions/wecom/src/ws-reply-context.ts
@@ -1,3 +1,4 @@
+import { appendWecomFooterText, buildWecomFooterText, resolveWecomFooterConfig, type ResolvedWecomFooterConfig } from "./footer.js";
 import type { WecomWsFrame } from "./ws-protocol.js";
 import {
   buildWecomWsRespondMediaCommand,
@@ -24,6 +25,7 @@ type WsMessageContext = {
   updatedAt: number;
   sessionKey?: string;
   runId?: string;
+  footer: ResolvedWecomFooterConfig;
   started: boolean;
   finished: boolean;
   queue: Promise<void>;
@@ -251,6 +253,10 @@ export function registerWecomWsMessageContext(params: {
   to: string;
   send: WsSendFrame;
   streamId?: string;
+  footer?: {
+    status?: boolean;
+    elapsed?: boolean;
+  };
 }): string {
   pruneContexts();
   const key = messageKey(params.accountId.trim(), params.reqId.trim());
@@ -265,6 +271,7 @@ export function registerWecomWsMessageContext(params: {
     pendingAutoImagePaths: [],
     createdAt: now(),
     updatedAt: now(),
+    footer: resolveWecomFooterConfig(params.footer),
     started: false,
     finished: false,
     queue: Promise.resolve(),
@@ -510,13 +517,22 @@ export async function finishWecomWsMessageContext(params: {
         ? `${context.content}\n\n${errorMessage}`
         : errorMessage
       : context.content;
-    const sendFinish = context.started || Boolean(finalContent) || context.msgItems.length > 0;
+    const finishContent = appendWecomFooterText(
+      finalContent || undefined,
+      buildWecomFooterText({
+        footer: context.footer,
+        createdAt: context.createdAt,
+        finishedAt: now(),
+        isError: Boolean(params.error),
+      })
+    );
+    const sendFinish = context.started || Boolean(finishContent) || context.msgItems.length > 0;
     if (sendFinish) {
       await context.send(
         buildWecomWsRespondMessageCommand({
           reqId: context.reqId,
           streamId: context.streamId,
-          content: finalContent || undefined,
+          content: finishContent,
           finish: true,
           msgItems: context.msgItems,
         })


### PR DESCRIPTION
## Summary
- add `channels.wecom.footer.status` and `channels.wecom.footer.elapsed`
- render footer metadata as a final text suffix for both ws and webhook stream replies
- document the new config and cover schema/merge/ws/webhook regressions with tests

## Why
Feishu already exposes footer metadata like elapsed time and final status. WeCom's main reply path is `msgtype: stream`, so it does not have a dedicated card footer slot. This PR brings the same user-facing signal to WeCom using a text footer on the final reply without changing the existing stream-first transport model.

## Implementation
- add a shared footer resolver/formatter in `extensions/wecom/src/footer.ts`
- extend WeCom config schema and plugin JSON with `footer.status` and `footer.elapsed`
- deep-merge top-level and per-account footer config so account overrides do not wipe defaults
- append footer text on ws finish and webhook stream finalization
- update docs with config examples and behavior notes

## Verification
- `pnpm -C extensions/wecom exec vitest run src/config.test.ts src/ws-reply-context.test.ts src/monitor.webhook.test.ts`
- `pnpm -C extensions/wecom build`
