### PR TITLE
fix(dingtalk): pass message-channel and session-key headers to gateway

### DIFF
--- a/extensions/dingtalk/src/bot-handler.ts
+++ b/extensions/dingtalk/src/bot-handler.ts
@@ -398,6 +398,7 @@ function resolveGatewayRequestParams(
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
+    "x-openclaw-message-channel": "dingtalk",
   };
   if (typeof authToken === "string" && authToken.trim()) {
     headers["Authorization"] = `Bearer ${authToken}`;
@@ -431,12 +432,14 @@ async function* streamFromGateway(params: {
 
   const response = await fetch(gatewayUrl, {
     method: "POST",
-    headers,
+    headers: {
+      ...headers,
+      "x-openclaw-session-key": sessionKey,
+    },
     body: JSON.stringify({
       model: "default",
       messages: [{ role: "user", content: userContent }],
       stream: true,
-      user: sessionKey,
     }),
     signal: abortSignal,
   });


### PR DESCRIPTION
- Add x-openclaw-message-channel header to identify the channel correctly
- Pass session key via x-openclaw-session-key header instead of body user field
- This fixes the issue where gateway defaults to "webchat" channel when the header is missing, causing agents to report incorrect channel information