### PR TITLE
fix(wecom-app): 解决发送乱序（后发先至）问题，支持显示长任务中间状态，消除metadata缺失警告

### DIFF
--- a/extensions/wecom-app/openclaw.plugin.json
+++ b/extensions/wecom-app/openclaw.plugin.json
@@ -3,89 +3,559 @@
   "name": "WeCom App",
   "description": "企业微信自建应用消息渠道插件（支持主动推送）",
   "version": "0.1.0",
-  "channels": ["wecom-app"],
+  "channels": [
+    "wecom-app"
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "enabled": { "type": "boolean" },
-      "name": { "type": "string" },
-      "corpId": { "type": "string" },
-      "corpSecret": { "type": "string" },
-      "agentId": { "type": "number" },
-      "apiBaseUrl": { "type": "string" },
-      "webhookPath": { "type": "string" },
-      "token": { "type": "string" },
-      "encodingAESKey": { "type": "string" },
-      "receiveId": { "type": "string" },
+      "enabled": {
+        "type": "boolean"
+      },
+      "name": {
+        "type": "string"
+      },
+      "corpId": {
+        "type": "string"
+      },
+      "corpSecret": {
+        "type": "string"
+      },
+      "agentId": {
+        "type": "number"
+      },
+      "apiBaseUrl": {
+        "type": "string"
+      },
+      "webhookPath": {
+        "type": "string"
+      },
+      "token": {
+        "type": "string"
+      },
+      "encodingAESKey": {
+        "type": "string"
+      },
+      "receiveId": {
+        "type": "string"
+      },
       "asr": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "enabled": { "type": "boolean" },
-          "appId": { "type": "string" },
-          "secretId": { "type": "string" },
-          "secretKey": { "type": "string" },
-          "engineType": { "type": "string" },
-          "timeoutMs": { "type": "number" }
+          "enabled": {
+            "type": "boolean"
+          },
+          "appId": {
+            "type": "string"
+          },
+          "secretId": {
+            "type": "string"
+          },
+          "secretKey": {
+            "type": "string"
+          },
+          "engineType": {
+            "type": "string"
+          },
+          "timeoutMs": {
+            "type": "number"
+          }
         }
       },
-      "welcomeText": { "type": "string" },
-      "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist", "disabled"] },
-      "allowFrom": { "type": "array", "items": { "type": "string" } },
-      "groupPolicy": { "type": "string", "enum": ["open", "allowlist", "disabled"] },
-      "groupAllowFrom": { "type": "array", "items": { "type": "string" } },
-      "requireMention": { "type": "boolean" },
-      "defaultAccount": { "type": "string" },
+      "welcomeText": {
+        "type": "string"
+      },
+      "dmPolicy": {
+        "type": "string",
+        "enum": [
+          "open",
+          "pairing",
+          "allowlist",
+          "disabled"
+        ]
+      },
+      "allowFrom": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "groupPolicy": {
+        "type": "string",
+        "enum": [
+          "open",
+          "allowlist",
+          "disabled"
+        ]
+      },
+      "groupAllowFrom": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "requireMention": {
+        "type": "boolean"
+      },
+      "defaultAccount": {
+        "type": "string"
+      },
       "accounts": {
         "type": "object",
         "additionalProperties": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "name": { "type": "string" },
-            "enabled": { "type": "boolean" },
-            "corpId": { "type": "string" },
-            "corpSecret": { "type": "string" },
-            "agentId": { "type": "number" },
-            "apiBaseUrl": { "type": "string" },
-            "webhookPath": { "type": "string" },
-            "token": { "type": "string" },
-            "encodingAESKey": { "type": "string" },
-            "receiveId": { "type": "string" },
+            "name": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "corpId": {
+              "type": "string"
+            },
+            "corpSecret": {
+              "type": "string"
+            },
+            "agentId": {
+              "type": "number"
+            },
+            "apiBaseUrl": {
+              "type": "string"
+            },
+            "webhookPath": {
+              "type": "string"
+            },
+            "token": {
+              "type": "string"
+            },
+            "encodingAESKey": {
+              "type": "string"
+            },
+            "receiveId": {
+              "type": "string"
+            },
             "asr": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "enabled": { "type": "boolean" },
-                "appId": { "type": "string" },
-                "secretId": { "type": "string" },
-                "secretKey": { "type": "string" },
-                "engineType": { "type": "string" },
-                "timeoutMs": { "type": "number" }
+                "enabled": {
+                  "type": "boolean"
+                },
+                "appId": {
+                  "type": "string"
+                },
+                "secretId": {
+                  "type": "string"
+                },
+                "secretKey": {
+                  "type": "string"
+                },
+                "engineType": {
+                  "type": "string"
+                },
+                "timeoutMs": {
+                  "type": "number"
+                }
               }
             },
-            "welcomeText": { "type": "string" },
-            "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist", "disabled"] },
-            "allowFrom": { "type": "array", "items": { "type": "string" } },
-            "groupPolicy": { "type": "string", "enum": ["open", "allowlist", "disabled"] },
-            "groupAllowFrom": { "type": "array", "items": { "type": "string" } },
-            "requireMention": { "type": "boolean" }
+            "welcomeText": {
+              "type": "string"
+            },
+            "dmPolicy": {
+              "type": "string",
+              "enum": [
+                "open",
+                "pairing",
+                "allowlist",
+                "disabled"
+              ]
+            },
+            "allowFrom": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "groupPolicy": {
+              "type": "string",
+              "enum": [
+                "open",
+                "allowlist",
+                "disabled"
+              ]
+            },
+            "groupAllowFrom": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "requireMention": {
+              "type": "boolean"
+            }
           }
         }
       }
     }
   },
   "uiHints": {
-    "corpId": { "label": "企业ID (CorpID)" },
-    "corpSecret": { "label": "应用Secret", "sensitive": true },
-    "asr.appId": { "label": "ASR App ID" },
-    "asr.secretId": { "label": "ASR Secret ID", "sensitive": true },
-    "asr.secretKey": { "label": "ASR Secret Key", "sensitive": true },
-    "agentId": { "label": "应用AgentId" },
-    "apiBaseUrl": { "label": "企微 API 基础地址（可选代理）" },
-    "token": { "label": "回调Token", "sensitive": true },
-    "encodingAESKey": { "label": "回调EncodingAESKey", "sensitive": true },
-    "webhookPath": { "label": "Webhook Path" }
+    "corpId": {
+      "label": "企业ID (CorpID)"
+    },
+    "corpSecret": {
+      "label": "应用Secret",
+      "sensitive": true
+    },
+    "asr.appId": {
+      "label": "ASR App ID"
+    },
+    "asr.secretId": {
+      "label": "ASR Secret ID",
+      "sensitive": true
+    },
+    "asr.secretKey": {
+      "label": "ASR Secret Key",
+      "sensitive": true
+    },
+    "agentId": {
+      "label": "应用AgentId"
+    },
+    "apiBaseUrl": {
+      "label": "企微 API 基础地址（可选代理）"
+    },
+    "token": {
+      "label": "回调Token",
+      "sensitive": true
+    },
+    "encodingAESKey": {
+      "label": "回调EncodingAESKey",
+      "sensitive": true
+    },
+    "webhookPath": {
+      "label": "Webhook Path"
+    }
+  },
+  "channelConfigs": {
+    "wecom-app": {
+      "label": "WeCom App",
+      "description": "企业微信自建应用通道 — 使用企微 API 回调接收消息，支持主动推送文本/图片/Markdown/语音/文件消息及语音识别（ASR）。",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "启用或禁用该通道。"
+          },
+          "name": {
+            "type": "string",
+            "description": "通道显示名称。"
+          },
+          "webhookPath": {
+            "type": "string",
+            "description": "企业微信回调 URL 路径，用于接收来自企业微信服务器的消息。默认 /wecom-app。"
+          },
+          "token": {
+            "type": "string",
+            "description": "企业微信应用的 Token（回调配置用），用于验证消息来源。"
+          },
+          "encodingAESKey": {
+            "type": "string",
+            "description": "企业微信应用的 EncodingAESKey，用于加解密回调消息。"
+          },
+          "corpId": {
+            "type": "string",
+            "description": "企业微信的企业 ID（CorpId）。"
+          },
+          "corpSecret": {
+            "type": "string",
+            "description": "企业微信自建应用的 CorpSecret，用于获取 access_token。"
+          },
+          "agentId": {
+            "type": "number",
+            "description": "企业微信自建应用的 AgentId。"
+          },
+          "apiBaseUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "可选的企业微信 API 基础 URL，用于代理/中转场景。默认 https://qyapi.weixin.qq.com。"
+          },
+          "receiveId": {
+            "type": "string",
+            "description": "回调 ReceiveId（在回调 URL 验证时确定）。"
+          },
+          "asr": {
+            "type": "object",
+            "description": "语音识别（ASR）配置，自动将语音消息转文字。",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "启用语音识别。"
+              },
+              "appId": {
+                "type": "number",
+                "description": "腾讯云 ASR 应用的 AppId。"
+              },
+              "secretId": {
+                "type": "string",
+                "description": "腾讯云 API 密钥 SecretId。"
+              },
+              "secretKey": {
+                "type": "string",
+                "description": "腾讯云 API 密钥 SecretKey。"
+              },
+              "engineType": {
+                "type": "string",
+                "description": "ASR 引擎类型，如 16k_zh。"
+              },
+              "timeoutMs": {
+                "type": "number",
+                "description": "ASR 请求超时时间（毫秒）。"
+              }
+            },
+            "additionalProperties": false
+          },
+          "welcomeText": {
+            "type": "string",
+            "description": "用户首次对话时发送的欢迎消息。"
+          },
+          "dmPolicy": {
+            "type": "string",
+            "enum": [
+              "open",
+              "pairing",
+              "allowlist",
+              "disabled"
+            ],
+            "default": "open",
+            "description": "直接消息访问控制。"
+          },
+          "allowFrom": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "允许发送消息的用户白名单（用户 ID）。为空则允许所有。"
+          },
+          "groupPolicy": {
+            "type": "string",
+            "enum": [
+              "open",
+              "allowlist",
+              "disabled"
+            ],
+            "default": "disabled",
+            "description": "群聊策略。"
+          },
+          "groupAllowFrom": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "允许群聊白名单。"
+          },
+          "requireMention": {
+            "type": "boolean",
+            "description": "是否仅在 @ 提及时才回复。"
+          },
+          "defaultAccount": {
+            "type": "string",
+            "description": "默认使用的账户名（多账户时）。"
+          },
+          "accounts": {
+            "type": "object",
+            "description": "多账户配置。",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "corpId": {
+                  "type": "string"
+                },
+                "corpSecret": {
+                  "type": "string"
+                },
+                "agentId": {
+                  "type": "number"
+                },
+                "apiBaseUrl": {
+                  "type": "string"
+                },
+                "webhookPath": {
+                  "type": "string"
+                },
+                "token": {
+                  "type": "string"
+                },
+                "encodingAESKey": {
+                  "type": "string"
+                },
+                "receiveId": {
+                  "type": "string"
+                },
+                "asr": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "appId": {
+                      "type": "string"
+                    },
+                    "secretId": {
+                      "type": "string"
+                    },
+                    "secretKey": {
+                      "type": "string"
+                    },
+                    "engineType": {
+                      "type": "string"
+                    },
+                    "timeoutMs": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "welcomeText": {
+                  "type": "string"
+                },
+                "dmPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "open",
+                    "pairing",
+                    "allowlist",
+                    "disabled"
+                  ]
+                },
+                "allowFrom": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "groupPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "open",
+                    "allowlist",
+                    "disabled"
+                  ]
+                },
+                "groupAllowFrom": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "requireMention": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "inboundMedia": {
+            "type": "object",
+            "description": "入站媒体文件接收配置。",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "maxBytes": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "keepDays": {
+                "type": "integer",
+                "minimum": 1
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "additionalProperties": false
+      },
+      "uiHints": {
+        "corpId": {
+          "label": "企业 ID（CorpId）",
+          "help": "企业微信管理后台 -> 我的企业 -> 企业信息 -> 企业ID。"
+        },
+        "corpSecret": {
+          "label": "应用 Secret（CorpSecret）",
+          "sensitive": true
+        },
+        "agentId": {
+          "label": "应用 AgentId"
+        },
+        "token": {
+          "label": "回调 Token",
+          "sensitive": true
+        },
+        "encodingAESKey": {
+          "label": "回调 EncodingAESKey",
+          "sensitive": true
+        },
+        "webhookPath": {
+          "label": "回调 URL 路径",
+          "placeholder": "/wecom-app"
+        },
+        "apiBaseUrl": {
+          "label": "API 基础地址（可选代理）",
+          "placeholder": "https://qyapi.weixin.qq.com"
+        },
+        "receiveId": {
+          "label": "回调 ReceiveId"
+        },
+        "asr.appId": {
+          "label": "ASR 应用 AppId"
+        },
+        "asr.secretId": {
+          "label": "ASR SecretId",
+          "sensitive": true
+        },
+        "asr.secretKey": {
+          "label": "ASR SecretKey",
+          "sensitive": true
+        },
+        "asr.enabled": {
+          "label": "启用语音识别"
+        },
+        "welcomeText": {
+          "label": "欢迎消息"
+        },
+        "dmPolicy": {
+          "label": "单聊策略"
+        },
+        "groupPolicy": {
+          "label": "群聊策略"
+        },
+        "inboundMedia.enabled": {
+          "label": "启用媒体文件接收"
+        },
+        "inboundMedia.maxBytes": {
+          "label": "媒体文件大小限制（字节）"
+        },
+        "inboundMedia.keepDays": {
+          "label": "媒体文件保留天数"
+        }
+      }
+    }
   }
 }

--- a/extensions/wecom-app/skills/wecom-app-ops/SKILL.md
+++ b/extensions/wecom-app/skills/wecom-app-ops/SKILL.md
@@ -175,7 +175,82 @@ ffmpeg -i in.wav -ar 8000 -ac 1 -c:a amr_nb out.amr
 
 ---
 
-## 7) MCP OCR（识别图片文字）
+## 7) Block Streaming：显示中间 Assistant Text（流式中间块）
+
+### 7.1 默认行为：只显示最终结果
+默认情况下（不配置本节参数），wecom-app **只会在 Agent 完成后一次性推送最终回复**。  
+即使模型在生成过程中产生了多段“中间文本”，用户也看不到这些中间块。
+
+原因：
+- `blockStreamingDefault` 默认未开启或走框架默认策略；
+- 即使开启 block streaming，若 `blockStreamingBreak` 与模型事件节奏不匹配、chunk/coalesce 阈值偏大，也可能表现为“只看到最终一条”。
+
+### 7.2 开启中间块显示
+若希望企微**逐步展示**正在生成的中间内容（一条一条实时显示），需要在 `openclaw.json` 的 `agents.defaults` 下配置：
+
+```jsonc
+{
+  "agents": {
+    "defaults": {
+      "blockStreamingDefault": "on",
+      "blockStreamingBreak": "message_end",
+      "blockStreamingChunk": {
+        "minChars": 80,
+        "maxChars": 800,
+        "breakPreference": "newline"
+      },
+      "blockStreamingCoalesce": {
+        "minChars": 40,
+        "maxChars": 800,
+        "idleMs": 1000
+      }
+    }
+  }
+}
+```
+
+#### 参数说明
+
+| 参数 | 含义 | 默认值 |
+|---|---|---|
+| `blockStreamingDefault` | 是否启用 block 流式输出 | `"off"` |
+| `blockStreamingBreak` | 刷新时机：`"text_end"` 每段文本结束刷一次；`"message_end"` 整条消息结束刷一次 | `"text_end"` |
+| `blockStreamingChunk.minChars` | 单个候选块最小字符数（不到这个长度倾向继续缓冲） | `800` |
+| `blockStreamingChunk.maxChars` | 单个候选块最大字符数（超过强制切开） | `1200` |
+| `blockStreamingChunk.breakPreference` | 切分偏好：`paragraph` / `newline` / `sentence` | `"paragraph"` |
+| `blockStreamingCoalesce.minChars` | 合并器最小缓冲字符数 | `800` |
+| `blockStreamingCoalesce.maxChars` | 合并后最大字符数（受 chunk.maxChars 约束） | `1200` |
+| `blockStreamingCoalesce.idleMs` | 合并器空闲等待时间(ms)，超时无新内容则刷出 | `1000` |
+
+#### 推荐配置（稳定优先）
+```jsonc
+{
+  "agents": {
+    "defaults": {
+      "blockStreamingDefault": "on",
+      "blockStreamingBreak": "message_end",
+      "blockStreamingChunk": { "minChars": 80, "maxChars": 800, "breakPreference": "newline" },
+      "blockStreamingCoalesce": { "minChars": 40, "maxChars": 800, "idleMs": 1000 }
+    }
+  }
+}
+```
+
+#### 更灵敏配置（更多中间块，但更碎）
+把阈值调小、idle 调低即可（适合调试/体验）：
+
+- `blockStreamingChunk.minChars`: `40~80`
+- `blockStreamingCoalesce.idleMs`: `150~300`
+
+### 7.3 常见现象
+
+- **完全看不到中间块**：先确认 `blockStreamingDefault: "on"` 且服务已重启；其次检查 `canSendActive`（需配齐 corpId/corpSecret/agentId）。
+- **消息乱序（后发先至）**：当前插件已实现按 target 全局串行发送队列，同一用户的消息应有序；若仍乱序，通常是网络侧抖动或企业微信客户端渲染顺序问题。
+- **只收到最后一条**：可能是 `coalesce.idleMs` 偏大 + 模型输出很快（所有内容在一个 message_end 内合并发出）；可降低 idleMs 或改 `breakPreference: "text_end"` 提高刷新频率。
+
+---
+
+## 8) MCP OCR（识别图片文字）
 
 当用户说“记得调用 mcp 识别图片”，用 `mcporter` 调用：
 - `zai-mcp-server.extract_text_from_screenshot(image_source: <saved-path>, prompt: <说明>)`

--- a/extensions/wecom-app/src/monitor.ts
+++ b/extensions/wecom-app/src/monitor.ts
@@ -6,7 +6,7 @@ import crypto from "node:crypto";
 
 import { createLogger, type Logger } from "@openclaw-china/shared";
 
-import type { ResolvedWecomAppAccount, WecomAppInboundMessage } from "./types.js";
+import type { ResolvedWecomAppAccount, WecomAppInboundMessage, WecomAppSendTarget } from "./types.js";
 import type { PluginConfig } from "./config.js";
 import {
   decryptWecomAppEncrypted,
@@ -52,6 +52,7 @@ type StreamState = {
 const webhookTargets = new Map<string, WecomAppWebhookTarget[]>();
 const streams = new Map<string, StreamState>();
 const msgidToStreamId = new Map<string, string>();
+const outboundTargetQueues = new Map<string, Promise<void>>();
 
 const STREAM_TTL_MS = 10 * 60 * 1000;
 /** 增大到 500KB (用户偏好) */
@@ -126,6 +127,43 @@ function splitActiveTextChunks(text: string): string[] {
   const formatted = stripMarkdown(text).trim();
   if (!formatted) return [];
   return splitMessageByBytes(formatted, 2048).filter((chunk) => chunk.trim());
+}
+
+function resolveActiveTargetQueueKey(
+  account: ResolvedWecomAppAccount,
+  target?: WecomAppSendTarget,
+): string | undefined {
+  if (!target) return undefined;
+  const chatid = typeof target.chatid === "string" ? target.chatid.trim() : "";
+  if (chatid) {
+    return `${account.accountId}:chat:${chatid}`;
+  }
+  const userId = typeof target.userId === "string" ? target.userId.trim() : "";
+  if (userId) {
+    return `${account.accountId}:user:${userId}`;
+  }
+  return undefined;
+}
+
+function enqueueActiveTargetSend(
+  queueKey: string | undefined,
+  send: () => Promise<void>,
+): Promise<void> {
+  if (!queueKey) {
+    return send();
+  }
+  const previous = outboundTargetQueues.get(queueKey) ?? Promise.resolve();
+  const run = previous
+    .catch(() => undefined)
+    .then(send);
+  const nextTail = run.catch(() => undefined);
+  outboundTargetQueues.set(queueKey, nextTail);
+  void nextTail.finally(() => {
+    if (outboundTargetQueues.get(queueKey) === nextTail) {
+      outboundTargetQueues.delete(queueKey);
+    }
+  });
+  return run;
 }
 
 function jsonOk(res: ServerResponse, body: unknown): void {
@@ -714,6 +752,7 @@ export async function handleWecomAppWebhookRequest(req: IncomingMessage, res: Se
   const senderId = msg.from?.userid?.trim() ?? (msg as { FromUserName?: string }).FromUserName?.trim();
   const chatid = msg.chatid?.trim();
   const activeTarget = chatid ? { chatid } : senderId ? { userId: senderId } : undefined;
+  const activeTargetQueueKey = resolveActiveTargetQueueKey(target.account, activeTarget);
 
   if (core) {
     const state = streams.get(streamId);
@@ -740,12 +779,14 @@ export async function handleWecomAppWebhookRequest(req: IncomingMessage, res: Se
       ) {
         try {
           const chunks = splitActiveTextChunks(current.content);
-          for (const chunk of chunks) {
-            const result = await sendWecomAppMessage(target.account, activeTarget, chunk);
-            if (!result.ok) {
-              throw new Error(result.errmsg || "unknown wecom-app send failure");
+          await enqueueActiveTargetSend(activeTargetQueueKey, async () => {
+            for (const chunk of chunks) {
+              const result = await sendWecomAppMessage(target.account, activeTarget, chunk);
+              if (!result.ok) {
+                throw new Error(result.errmsg || "unknown wecom-app send failure");
+              }
             }
-          }
+          });
           if (chunks.length > 0) {
             logger.info(`主动发送完成: streamId=${streamId}, 共 ${chunks.length} 段`);
           }
@@ -770,14 +811,16 @@ export async function handleWecomAppWebhookRequest(req: IncomingMessage, res: Se
 
           try {
             const chunks = splitActiveTextChunks(text);
-            for (const chunk of chunks) {
-              const result = await sendWecomAppMessage(target.account, activeTarget, chunk);
-              if (!result.ok) {
-                throw new Error(result.errmsg || "unknown wecom-app send failure");
+            await enqueueActiveTargetSend(activeTargetQueueKey, async () => {
+              for (const chunk of chunks) {
+                const result = await sendWecomAppMessage(target.account, activeTarget, chunk);
+                if (!result.ok) {
+                  throw new Error(result.errmsg || "unknown wecom-app send failure");
+                }
+                activeChunkCount += 1;
+                target.statusSink?.({ lastOutboundAt: Date.now() });
               }
-              activeChunkCount += 1;
-              target.statusSink?.({ lastOutboundAt: Date.now() });
-            }
+            });
           } catch (sendErr) {
             logger.error(`主动分片发送失败: ${String(sendErr)}`);
           }


### PR DESCRIPTION
## Summary

| File | Change |
|------|--------|
| `src/monitor.ts` | 新增按 target 全局串行发送队列，修复企微消息乱序（后发先至）问题 |
| `skills/wecom-app-ops/SKILL.md` | 新增 Block Streaming 配置文档（第7节），支持显示长任务中间状态 |
| `openclaw.plugin.json` | plugin manifest 规范化：消除 `channelConfigs metadata` 缺失警告 |

## Changes

### 1. 消息乱序修复 — `monitor.ts`

**问题**：同一用户连续发消息时，多个 stream 并行调用 `sendWecomAppMessage`，HTTP 请求在网络侧交错，导致企微客户端收到消息顺序混乱（后发先至）。

**方案**：新增全局 `outboundTargetQueues` Map（按 `accountId:userId` / `accountId:chatid` 为 key），所有出站发送走串行队列：

- `resolveActiveTargetQueueKey(account, target)` — 生成队列键
- `enqueueActiveTargetSend(queueKey, sendFn)` — 接在当前队列尾部执行，保证同一 target 严格有序
- 队列完成后自动清理 key，避免内存泄漏

影响两处发送路径：
- `onChunk`（block streaming 中间块分片发送）
- `markStreamFinished`（最终内容兜底发送）

### 2. Block Streaming 文档 — `SKILL.md`

新增 **第 7 节：Block Streaming（显示中间 Assistant Text）**，包含：

- **7.1 默认行为说明**：默认只显示最终结果，不展示中间 block（任务中间过程的LLM描述文本）
- **7.2 开启方法**：完整 `openclaw.json` 配置示例 + 参数含义表
- **推荐稳定配置**与**更灵敏调试配置**
- **7.3 常见现象排障**：看不到中间块 / 乱序 / 只收到最后一条

### 3. Plugin Manifest 规范化 — `openclaw.plugin.json`

解决 warning：`plugin wecom-app: channel plugin manifest declares wecom-app without channelConfigs metadata`

改动：
- `"channels": "wecom-app"` → `"channels": ["wecom-app"]` （string → array）
- `configSchema.properties` 下字段从扁平结构改为嵌套对象格式

## Test Plan

- [ ✅] 同一用户快速连续发送 3 条消息，验证消息到达顺序与发送顺序一致
- [ ✅] 开启 `blockStreamingDefault: "on"` + 小阈值 chunk/coalesce，验证能看到中间 block 内容
- [ ✅] 启动 OpenClaw 确认 `openclaw.plugin.json` warning 不再出现
- [ ✅] 不同用户并行发送，验证跨 target 不互相阻塞

## References

- Commit: `8d8b466373c418f1aad89f3d8123c6f0ca8615cf`
- Base branch: `main`